### PR TITLE
feat: トップページを本格的な LP に刷新する

### DIFF
--- a/.claude/steering/issue-9-top-page-lp-renewal.md
+++ b/.claude/steering/issue-9-top-page-lp-renewal.md
@@ -1,0 +1,79 @@
+# Issue #9: トップページを本格的な LP に刷新する
+
+## 背景
+
+現在のトップページ（`apps/web/src/app/[locale]/page.tsx`）はヘッダー・ヒーロー・機能カード 6 枚・スタックバッジのみの最小構成。
+E-be のターゲット（バーオーナー・イベンター）に向けた課題提起・価値提案・使い方フローを盛り込み、
+コンバージョンを意識した本格的な LP にリニューアルする。
+
+## 参照
+
+- GitHub Issue: #9
+- 関連ドキュメント:
+  - `docs/features/index.md`（機能一覧）
+  - `docs/features/bar-search.md`（バー検索機能）
+  - `docs/features/event-search.md`（イベント検索機能）
+  - `docs/architecture/decisions.md` #2（多言語設計）
+  - `.claude/steering/i18n.md`（next-intl 設定・翻訳キー規則）
+
+## 実装方針
+
+- **Server Component のまま維持**。スクロール固定ヘッダーのみ `'use client'` を最小限に切り出す
+- **画像・動画は使わない**。アイコン（絵文字）・Tailwind グラデーション・シェイプで視覚的に表現
+- **shadcn/ui のコンポーネントを使う**（`Card`, `Badge`, `Button`, `Separator`）
+- **モバイルファースト**。`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` を基本とする
+- **CTA ボタンは現時点でダミーリンク（`href="#"`）**。機能実装後に差し替える
+- **i18n 必須**。`en.json` と `ja.json` の両方に翻訳キーを追加する
+
+## 実装ステップ
+
+1. **翻訳キーを設計する**（実装前に ja/en の全キーを洗い出す）
+   - 既存の `home.*` キーを拡張し、新セクション分を追加
+   - キー構造: `home.nav.*`, `home.hero.*`, `home.pain.*`, `home.features.*`, `home.how.*`, `home.cta.*`, `home.footer.*`
+
+2. **`apps/web/messages/ja.json` に翻訳キーを追加**
+
+3. **`apps/web/messages/en.json` に翻訳キーを追加**
+
+4. **`apps/web/src/app/[locale]/page.tsx` をリニューアル**
+   以下のセクションを順番に実装する:
+
+   | セクション | 実装内容 |
+   |-----------|---------|
+   | `<NavBar>` | ロゴ・サインイン・サインアップ。スクロール検知で背景をつける（`'use client'` の薄いラッパー） |
+   | `<HeroSection>` | キャッチコピー・サブコピー・2つの CTA（「イベントを探す」「開催を申し込む」） |
+   | `<PainSection>` | 「こんな悩みありませんか？」バーオーナー / イベンターの 2 カラム課題リスト |
+   | `<FeaturesSection>` | 機能 6 件をアイコン付きカードで表示（既存を充実化） |
+   | `<HowSection>` | 「登録 → 申請 → 開催」の 3 ステップ図解 |
+   | `<CtaBanner>` | 「今すぐはじめる」大きめバナー |
+   | `<Footer>` | コピーライト・リンク集（プライバシー・利用規約は `href="#"` のダミー） |
+
+5. **Playwright MCP で動作確認**（`/pw-verify`）
+
+## コンポーネント分割の指針
+
+- セクションが長くなる場合は `apps/web/src/components/lp/` 以下に分割してもよい
+- ただし各セクションが軽量であれば `page.tsx` に inline でも可
+- スクロール固定ヘッダーのみ `'use client'` が必要なため、薄いラッパー `NavBar` を分割することを推奨
+
+## 影響範囲
+
+- `apps/web/src/app/[locale]/page.tsx` — 全面書き換え
+- `apps/web/messages/ja.json` — `home.*` キー拡張
+- `apps/web/messages/en.json` — `home.*` キー拡張
+- （必要に応じて）`apps/web/src/components/lp/` 新規作成
+
+## チェックリスト
+
+- [ ] `ja.json` / `en.json` に全翻訳キーを追加した
+- [ ] NavBar: ロゴ・サインイン・サインアップリンクが表示される
+- [ ] NavBar: スクロール時に背景が現れる（`'use client'` の薄いラッパー）
+- [ ] Hero: キャッチコピー・サブコピー・2つの CTA ボタンが表示される
+- [ ] Pain: バーオーナー / イベンターの課題が 2 カラムで表示される
+- [ ] Features: 機能 6 件がカードで表示される
+- [ ] How: 3 ステップフローが表示される
+- [ ] CtaBanner: 大きめバナーが表示される
+- [ ] Footer: コピーライト・リンクが表示される
+- [ ] モバイル（375px 幅）で崩れがない
+- [ ] `/ja/` と `/en/` の両方で翻訳が表示される
+- [ ] `'use client'` の使用は NavBar のみ（または最小限）

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -8,13 +8,59 @@
     "cta_request": "Request an Event",
     "features_title": "Features",
     "stack_title": "Tech Stack",
+    "nav": {
+      "sign_in": "Sign In",
+      "sign_up": "Get Started Free",
+      "dashboard": "Dashboard"
+    },
+    "hero": {
+      "eyebrow": "The Event Bar Platform",
+      "title": "More Great Events, Together.",
+      "subtitle": "E-be connects venues with organizers. Handle bookings, attendance, and analytics — all in one place.",
+      "cta_primary": "Find Events",
+      "cta_secondary": "Book a Venue"
+    },
+    "pain": {
+      "title": "Sound familiar?",
+      "venue_label": "Bar Owners & Venue Staff",
+      "venue_item_1": "Hard to find reliable organizers you can trust",
+      "venue_item_2": "Managing schedules across multiple venues is a mess",
+      "venue_item_3": "No clear way to measure which events actually drive revenue",
+      "venue_item_4": "Booking requests and approvals take too long",
+      "eventer_label": "Organizers, DJs & Artists",
+      "eventer_item_1": "Finding a venue takes too much time every single time",
+      "eventer_item_2": "Coordination is scattered across emails and messages",
+      "eventer_item_3": "No good way to showcase your past track record",
+      "eventer_item_4": "Missing tools to build repeat audiences with coupons"
+    },
     "features": {
-      "events": { "title": "Event Management", "description": "Centralized request, approval, and time conflict checking" },
-      "multitenant": { "title": "Multi-tenant", "description": "Manage multiple venues under one organization" },
-      "participants": { "title": "Participant Management", "description": "Flexible roles: organizer, co-host, and participant" },
-      "ai": { "title": "AI Analytics", "description": "Export performance data as AI-ready text for analysis" },
-      "coupons": { "title": "Coupons", "description": "Issue venue-specific or organization-wide coupons" },
-      "fc": { "title": "FC Requests", "description": "Apply to open new venues and match based on past performance" }
+      "title": "Everything you need to run great events",
+      "events": { "title": "Event Management", "description": "Centralized booking requests, approvals, and schedule conflict checking across all your venues." },
+      "multitenant": { "title": "Multi-venue", "description": "One organization, many venues. Manage each independently while keeping a unified overview." },
+      "participants": { "title": "Attendance & Roles", "description": "Flexible roles for organizers, co-hosts, and attendees. Track capacity and RSVPs in one view." },
+      "ai": { "title": "AI-Ready Analytics", "description": "Export your performance data as structured text for AI analysis. Spot trends and popular tags fast." },
+      "coupons": { "title": "Coupons", "description": "Issue venue-specific or org-wide coupons to drive repeat attendance and reward loyal guests." },
+      "fc": { "title": "FC Requests", "description": "Let top organizers apply to open new venues, matched by past performance data." }
+    },
+    "how": {
+      "title": "Up and running in 3 steps",
+      "step_1_title": "Create an account",
+      "step_1_desc": "Sign up free with just your email. Works for venue owners and organizers alike.",
+      "step_2_title": "Choose a venue & apply",
+      "step_2_desc": "Browse available venues and submit a booking request. Proven organizers get fast-tracked.",
+      "step_3_title": "Host your event",
+      "step_3_desc": "Once approved, your event goes live. Manage RSVPs, coupons, and post-event reports — all here."
+    },
+    "cta_section": {
+      "title": "Ready to create better events?",
+      "subtitle": "Create a free account and start connecting with venues and organizers today.",
+      "button": "Get Started Free"
+    },
+    "footer": {
+      "copyright": "© 2026 E-be. All rights reserved.",
+      "terms": "Terms of Service",
+      "privacy": "Privacy Policy",
+      "contact": "Contact"
     }
   },
   "auth": {
@@ -45,6 +91,10 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "calendar_title": "Event Calendar",
+    "user_type_user": "User",
+    "user_type_venue_user": "Venue Operator",
+    "user_type_system_user": "Admin",
     "sign_out": "Sign Out",
     "orgs_title": "Your Organizations",
     "no_orgs": "You are not a member of any organization",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -8,13 +8,59 @@
     "cta_request": "開催リクエスト",
     "features_title": "主要機能",
     "stack_title": "技術スタック",
+    "nav": {
+      "sign_in": "サインイン",
+      "sign_up": "無料で始める",
+      "dashboard": "ダッシュボードへ"
+    },
+    "hero": {
+      "eyebrow": "イベントバー特化プラットフォーム",
+      "title": "「良いイベント」を、もっと。",
+      "subtitle": "バーとイベンターをつなぐプラットフォーム。開催申請・参加管理・実績分析まで E-be が一括サポートします。",
+      "cta_primary": "イベントを探す",
+      "cta_secondary": "開催を申し込む"
+    },
+    "pain": {
+      "title": "こんな悩みはありませんか？",
+      "venue_label": "バーオーナー・店舗スタッフ",
+      "venue_item_1": "信頼できるイベンターをなかなか見つけられない",
+      "venue_item_2": "複数店舗の予定管理が煩雑になっている",
+      "venue_item_3": "集客効果を数字で把握・比較できていない",
+      "venue_item_4": "申込・承認のやり取りに時間がかかりすぎる",
+      "eventer_label": "イベンター・DJ・アーティスト",
+      "eventer_item_1": "会場探しに毎回多くの時間を費やしている",
+      "eventer_item_2": "申し込みや調整のやり取りが分散して管理しにくい",
+      "eventer_item_3": "過去の実績をうまくアピールする場がない",
+      "eventer_item_4": "クーポンやリピーター獲得の仕組みを持てていない"
+    },
     "features": {
-      "events": { "title": "イベント管理", "description": "開催リクエスト・承認・時間重複チェックを一元管理" },
-      "multitenant": { "title": "マルチテナント", "description": "1事業者 = N店舗の階層構造で運営をシンプルに" },
-      "participants": { "title": "参加者管理", "description": "主催者・共催者・参加者のロールを柔軟に管理" },
-      "ai": { "title": "AI分析基盤", "description": "実績データをAI分析用テキストとしてエクスポート" },
-      "coupons": { "title": "クーポン", "description": "店舗限定・事業者全店共通クーポンを発行" },
-      "fc": { "title": "FCリクエスト", "description": "新店舗オーナー立候補と過去実績マッチング" }
+      "title": "E-be の主な機能",
+      "events": { "title": "イベント管理", "description": "開催リクエスト・承認・時間重複チェックを一元管理。複数店舗の予定をひと目で把握できます。" },
+      "multitenant": { "title": "マルチテナント", "description": "1事業者 = N店舗の階層構造で運営をシンプルに。各店舗の実績を分けて管理できます。" },
+      "participants": { "title": "参加者管理", "description": "主催者・共催者・参加者のロールを柔軟に管理。定員設定や参加状況を一覧で確認。" },
+      "ai": { "title": "AI分析基盤", "description": "実績データをAI分析用テキストとしてエクスポート。集客傾向・人気タグを素早く把握。" },
+      "coupons": { "title": "クーポン発行", "description": "店舗限定・事業者全店共通クーポンを発行。リピーター獲得・次回来店促進に活用できます。" },
+      "fc": { "title": "FCリクエスト", "description": "新店舗オーナーへの立候補と過去実績マッチング。優秀なイベンターを新拠点へ繋げます。" }
+    },
+    "how": {
+      "title": "はじめ方はかんたん 3 ステップ",
+      "step_1_title": "アカウント登録",
+      "step_1_desc": "メールアドレスだけで無料登録。バーオーナー・イベンターどちらでもすぐに利用開始できます。",
+      "step_2_title": "店舗を選んで申請",
+      "step_2_desc": "気になる会場を見つけて開催申請。過去の実績があれば即承認も可能です。",
+      "step_3_title": "イベントを開催",
+      "step_3_desc": "承認後はカレンダーに掲載。参加申込・クーポン配布・実績管理まで一括対応。"
+    },
+    "cta_section": {
+      "title": "今すぐ E-be をはじめましょう",
+      "subtitle": "無料でアカウントを作成して、より良いイベント体験を。",
+      "button": "無料で始める"
+    },
+    "footer": {
+      "copyright": "© 2026 E-be. All rights reserved.",
+      "terms": "利用規約",
+      "privacy": "プライバシーポリシー",
+      "contact": "お問い合わせ"
     }
   },
   "auth": {
@@ -45,6 +91,10 @@
   },
   "dashboard": {
     "title": "ダッシュボード",
+    "calendar_title": "イベントカレンダー",
+    "user_type_user": "一般ユーザー",
+    "user_type_venue_user": "事業者",
+    "user_type_system_user": "管理者",
     "sign_out": "サインアウト",
     "orgs_title": "所属組織",
     "no_orgs": "所属している組織はありません",

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,9 +1,10 @@
 import { getLocale, getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { getUser } from "@/lib/auth";
 import Link from "next/link";
+import { NavBar } from "@/components/lp/nav-bar";
+import { LinkButton } from "@/components/lp/link-button";
 
 const featureKeys = [
   { key: "events", icon: "🎪" },
@@ -12,6 +13,26 @@ const featureKeys = [
   { key: "ai", icon: "🤖" },
   { key: "coupons", icon: "🎫" },
   { key: "fc", icon: "🤝" },
+] as const;
+
+const venueItemKeys = [
+  "pain.venue_item_1",
+  "pain.venue_item_2",
+  "pain.venue_item_3",
+  "pain.venue_item_4",
+] as const;
+
+const eventerItemKeys = [
+  "pain.eventer_item_1",
+  "pain.eventer_item_2",
+  "pain.eventer_item_3",
+  "pain.eventer_item_4",
+] as const;
+
+const howSteps = [
+  { titleKey: "how.step_1_title", descKey: "how.step_1_desc" },
+  { titleKey: "how.step_2_title", descKey: "how.step_2_desc" },
+  { titleKey: "how.step_3_title", descKey: "how.step_3_desc" },
 ] as const;
 
 export default async function HomePage() {
@@ -23,93 +44,183 @@ export default async function HomePage() {
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      {/* Header */}
-      <header className="border-b">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <span className="font-bold">E-be</span>
-          {user ? (
-            <Link
-              href={`/${locale}/dashboard`}
-              className="inline-flex h-7 items-center rounded-lg border border-border bg-background px-2.5 text-[0.8rem] font-medium transition-all hover:bg-muted"
-            >
-              ダッシュボード
-            </Link>
-          ) : (
-            <Link
-              href={`/${locale}/auth/sign-in`}
-              className="inline-flex h-7 items-center rounded-lg border border-border bg-background px-2.5 text-[0.8rem] font-medium transition-all hover:bg-muted"
-            >
-              サインイン
-            </Link>
-          )}
-        </div>
-      </header>
+      <NavBar
+        locale={locale}
+        isLoggedIn={!!user}
+        labels={{
+          signIn: t("nav.sign_in"),
+          signUp: t("nav.sign_up"),
+          dashboard: t("nav.dashboard"),
+        }}
+      />
 
       {/* Hero */}
-      <section className="border-b">
-        <div className="mx-auto max-w-5xl px-6 py-24 text-center">
-          <Badge variant="outline" className="mb-6 font-mono text-xs cursor-pointer">
-            {t("badge")}
+      <section className="relative overflow-hidden border-b pt-16">
+        {/* Decorative blobs */}
+        <div className="pointer-events-none absolute -right-40 -top-40 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
+
+        <div className="relative mx-auto max-w-5xl px-6 py-28 text-center">
+          <Badge variant="outline" className="mb-6 cursor-pointer font-mono text-xs">
+            {t("hero.eyebrow")}
           </Badge>
-          <h1 className="mb-4 text-5xl font-bold tracking-tight">
-            {t("title")}{" "}
-            <span className="text-muted-foreground font-light">E-be</span>
+          <h1 className="mb-5 text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            {t("hero.title")}
           </h1>
-          <p className="mx-auto mb-8 max-w-xl text-lg text-muted-foreground">
-            {t("tagline")}
-            <br />
-            {t("description")}
+          <p className="mx-auto mb-10 max-w-lg text-base text-muted-foreground sm:text-lg">
+            {t("hero.subtitle")}
           </p>
-          <div className="flex justify-center gap-3">
-            <Button size="lg" className="transition-all duration-200 hover:scale-105 hover:shadow-md cursor-pointer">
-              {t("cta_search")}
-            </Button>
-            <Button size="lg" variant="outline" className="transition-all duration-200 hover:scale-105 hover:shadow-md cursor-pointer">
-              {t("cta_request")}
-            </Button>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <LinkButton href="#" size="lg" className="w-full sm:w-auto">
+              {t("hero.cta_primary")}
+            </LinkButton>
+            <LinkButton href="#" size="lg" variant="outline" className="w-full sm:w-auto">
+              {t("hero.cta_secondary")}
+            </LinkButton>
+          </div>
+        </div>
+      </section>
+
+      {/* Pain — 課題提起 */}
+      <section className="border-b bg-muted/20">
+        <div className="mx-auto max-w-5xl px-6 py-20">
+          <h2 className="mb-12 text-center text-2xl font-semibold sm:text-3xl">
+            {t("pain.title")}
+          </h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {/* バーオーナー */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <span className="text-2xl">🏪</span>
+                  {t("pain.venue_label")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3">
+                  {venueItemKeys.map((key) => (
+                    <li key={key} className="flex items-start gap-2 text-sm text-muted-foreground">
+                      <span className="mt-0.5 shrink-0 text-destructive">✕</span>
+                      {t(key)}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+
+            {/* イベンター */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <span className="text-2xl">🎤</span>
+                  {t("pain.eventer_label")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3">
+                  {eventerItemKeys.map((key) => (
+                    <li key={key} className="flex items-start gap-2 text-sm text-muted-foreground">
+                      <span className="mt-0.5 shrink-0 text-destructive">✕</span>
+                      {t(key)}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </section>
 
       {/* Features */}
-      <section className="mx-auto max-w-5xl px-6 py-20">
-        <h2 className="mb-10 text-center text-2xl font-semibold">
-          {t("features_title")}
-        </h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {featureKeys.map(({ key, icon }) => (
-            <Card key={key} className="transition-all duration-200 hover:bg-muted/50 hover:shadow-md hover:-translate-y-0.5 cursor-pointer">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <span className="text-2xl">{icon}</span>
-                  {t(`features.${key}.title`)}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  {t(`features.${key}.description`)}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
-
-      {/* Stack */}
-      <section className="border-t bg-muted/30">
-        <div className="mx-auto max-w-5xl px-6 py-12 text-center">
-          <p className="mb-4 text-sm text-muted-foreground">{t("stack_title")}</p>
-          <div className="flex flex-wrap justify-center gap-2">
-            {["Turborepo", "Next.js 16", "Expo", "Supabase", "Drizzle ORM", "Tailwind CSS", "shadcn/ui"].map(
-              (tech) => (
-                <Badge key={tech} variant="secondary" className="font-mono text-xs">
-                  {tech}
-                </Badge>
-              )
-            )}
+      <section className="border-b">
+        <div className="mx-auto max-w-5xl px-6 py-20">
+          <h2 className="mb-10 text-center text-2xl font-semibold sm:text-3xl">
+            {t("features.title")}
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {featureKeys.map(({ key, icon }) => (
+              <Card
+                key={key}
+                className="transition-all duration-200 hover:-translate-y-0.5 hover:bg-muted/50 hover:shadow-md"
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <span className="text-2xl">{icon}</span>
+                    {t(`features.${key}.title`)}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">
+                    {t(`features.${key}.description`)}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         </div>
       </section>
+
+      {/* How it works */}
+      <section className="border-b bg-muted/20">
+        <div className="mx-auto max-w-5xl px-6 py-20">
+          <h2 className="mb-14 text-center text-2xl font-semibold sm:text-3xl">
+            {t("how.title")}
+          </h2>
+          <div className="relative grid grid-cols-1 gap-10 sm:grid-cols-3">
+            {/* Connecting line — desktop only */}
+            <div className="absolute hidden sm:block top-7 left-[calc(16.667%+28px)] right-[calc(16.667%+28px)] h-px bg-border" />
+
+            {howSteps.map(({ titleKey, descKey }, idx) => (
+              <div key={titleKey} className="flex flex-col items-center text-center">
+                <div className="relative mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-foreground font-bold text-background text-lg">
+                  {String(idx + 1).padStart(2, "0")}
+                </div>
+                <h3 className="mb-2 font-semibold">{t(titleKey)}</h3>
+                <p className="text-sm text-muted-foreground">{t(descKey)}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Banner */}
+      <section className="border-b">
+        <div className="relative overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-muted/40 via-background to-muted/40" />
+          <div className="relative mx-auto max-w-5xl px-6 py-24 text-center">
+            <h2 className="mb-4 text-2xl font-bold sm:text-3xl lg:text-4xl">
+              {t("cta_section.title")}
+            </h2>
+            <p className="mb-8 text-muted-foreground">
+              {t("cta_section.subtitle")}
+            </p>
+            <LinkButton href="#" size="lg" className="min-w-40">
+              {t("cta_section.button")}
+            </LinkButton>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6 py-10">
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+            <span className="font-bold">E-be</span>
+            <p className="text-xs text-muted-foreground">{t("footer.copyright")}</p>
+            <div className="flex gap-4 text-xs text-muted-foreground">
+              <Link href="#" className="transition-colors hover:text-foreground">
+                {t("footer.terms")}
+              </Link>
+              <Link href="#" className="transition-colors hover:text-foreground">
+                {t("footer.privacy")}
+              </Link>
+              <Link href="#" className="transition-colors hover:text-foreground">
+                {t("footer.contact")}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </footer>
     </main>
   );
 }

--- a/apps/web/src/components/lp/link-button.tsx
+++ b/apps/web/src/components/lp/link-button.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "outline" | "ghost";
+type Size = "sm" | "default" | "lg";
+
+interface LinkButtonProps {
+  href: string;
+  variant?: Variant;
+  size?: Size;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const base =
+  "inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent text-sm font-medium whitespace-nowrap transition-all select-none";
+
+const variants: Record<Variant, string> = {
+  default: "bg-primary text-primary-foreground hover:bg-primary/80",
+  outline:
+    "border-border bg-background hover:bg-muted hover:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+  ghost: "hover:bg-muted hover:text-foreground",
+};
+
+const sizes: Record<Size, string> = {
+  sm: "h-7 gap-1 px-2.5 text-[0.8rem]",
+  default: "h-8 gap-1.5 px-2.5",
+  lg: "h-9 gap-1.5 px-3",
+};
+
+export function LinkButton({
+  href,
+  variant = "default",
+  size = "default",
+  className,
+  children,
+}: LinkButtonProps) {
+  return (
+    <Link href={href} className={cn(base, variants[variant], sizes[size], className)}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/components/lp/nav-bar.tsx
+++ b/apps/web/src/components/lp/nav-bar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface NavBarProps {
+  locale: string;
+  isLoggedIn: boolean;
+  labels: {
+    signIn: string;
+    signUp: string;
+    dashboard: string;
+  };
+}
+
+const btnBase =
+  "inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent text-sm font-medium whitespace-nowrap transition-all select-none h-7 gap-1 px-2.5 text-[0.8rem]";
+
+export function NavBar({ locale, isLoggedIn, labels }: NavBarProps) {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setScrolled(window.scrollY > 10);
+    window.addEventListener("scroll", handler, { passive: true });
+    return () => window.removeEventListener("scroll", handler);
+  }, []);
+
+  return (
+    <header
+      className={cn(
+        "fixed left-0 right-0 top-0 z-50 transition-all duration-300",
+        scrolled && "border-b bg-background/95 shadow-sm backdrop-blur-sm"
+      )}
+    >
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 h-16">
+        <Link href={`/${locale}`} className="text-lg font-bold tracking-tight">
+          E-be
+        </Link>
+        <div className="flex items-center gap-2">
+          {isLoggedIn ? (
+            <Link
+              href={`/${locale}/dashboard`}
+              className={cn(btnBase, "bg-primary text-primary-foreground hover:bg-primary/80")}
+            >
+              {labels.dashboard}
+            </Link>
+          ) : (
+            <>
+              <Link
+                href={`/${locale}/auth/sign-in`}
+                className={cn(btnBase, "hover:bg-muted hover:text-foreground")}
+              >
+                {labels.signIn}
+              </Link>
+              <Link
+                href={`/${locale}/auth/sign-up`}
+                className={cn(btnBase, "bg-primary text-primary-foreground hover:bg-primary/80")}
+              >
+                {labels.signUp}
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

- ヒーロー・課題提起・機能・3ステップ・CTAバナー・フッターの 7 セクション構成に拡張
- スクロール検知で背景が現れる固定ナビバー（`NavBar` client component）を追加
- `buttonVariants` がサーバー非対応のため `LinkButton` server component を新設
- ja/en 翻訳キーを全セクション分追加
- モバイルファースト・shadcn/ui Card 利用・Server Component を維持

Closes #9

## Test plan

- [ ] `/ja` で全セクションが日本語表示される
- [ ] `/en` で全セクションが英語表示される
- [ ] NavBar スクロール時に背景が現れる
- [ ] ヒーロー・CTA バナーのボタンリンクが機能する
- [ ] モバイル幅（375px）でレイアウト崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)