### PR TITLE
feat: ダッシュボードに主催イベント履歴を表示する (#15)

### DIFF
--- a/.claude/steering/issue-15-organizer-event-history.md
+++ b/.claude/steering/issue-15-organizer-event-history.md
@@ -1,0 +1,59 @@
+# Issue #15: ダッシュボードに主催イベント履歴を表示する
+
+## 背景
+
+ログインユーザーが過去に主催したイベントの一覧をダッシュボードに表示する。
+イベンターが自分の実績を確認できるようにすることが目的。
+
+## 参照
+
+- GitHub Issue: #15
+- 関連ドキュメント: `docs/features/organizer-history.md`
+- 既存実装: `apps/web/src/lib/events.ts`（`getEventsForCalendar` 関数）
+- ダッシュボードページ: `apps/web/src/app/[locale]/dashboard/page.tsx`
+- DBスキーマ: `packages/db/src/schema.ts`（`events` テーブル: `userId` = 作成者）
+
+## 実装方針
+
+- `events.userId = 現在のユーザーID` で絞り込む
+- 表示対象ステータス: `completed`（自分のダッシュボードのみ `cancelled` / `rejected` も表示）
+  - ※ `eventStatusEnum` に `completed` がない点に注意 → スキーマ確認必須（Issue 記載では `completed` だが現在の enum にない）
+  - **TBD**: `completed` ステータスがスキーマに存在しない場合の扱い → `docs/features/organizer-history.md` では `completed` になったイベントのみ対象。現状の enum は `draft/pending/published/cancelled/rejected` のみ。`published` かつ `endAt < now` を「完了」とみなす設計原則に従う
+- 新しい順（`startAt DESC` または `createdAt DESC`）に表示
+- 公開/非公開設定は別 Issue（本 Issue では全件表示）
+
+## 実装ステップ
+
+1. `apps/web/src/lib/events.ts` に `getOrganizerHistory` 関数を追加
+   - 引数: `userId: string`
+   - 取得条件: `userId = 引数` かつ `deletedAt IS NULL` かつ `endAt < now`（完了扱い）または status が `published/cancelled/rejected`
+   - ※ `completed` ステータスが存在しないため「`endAt` が過去かつ `published`」を completed 相当とみなす
+   - cancelled/rejected は自分のダッシュボード用なので全件取得
+   - 返却フィールド: `id`, `title`, `startAt`, `endAt`, `status`, `orgId`
+2. `apps/web/src/app/[locale]/dashboard/page.tsx` に主催履歴カードを追加
+   - `getOrganizerHistory(user.id)` を呼び出す
+   - `userType === 'user'`（イベンター）の場合のみ表示
+   - カードタイトル: 翻訳キー `dashboard.organizer_history_title`
+   - 一覧はイベント名・開催日・ステータスを表示
+   - 空の場合は「履歴はまだありません」表示
+3. 翻訳キーを追加
+   - `apps/web/messages/ja.json` の `dashboard` セクション
+   - `apps/web/messages/en.json` の `dashboard` セクション
+
+## 影響範囲
+
+- `apps/web/src/lib/events.ts` — 関数追加
+- `apps/web/src/app/[locale]/dashboard/page.tsx` — カード追加
+- `apps/web/messages/ja.json` — 翻訳キー追加
+- `apps/web/messages/en.json` — 翻訳キー追加
+
+## チェックリスト
+
+- [ ] `getOrganizerHistory(userId)` 関数を `events.ts` に追加
+- [ ] `completed` ステータス相当のロジック（`endAt < now` かつ `published`）を実装
+- [ ] `cancelled` / `rejected` もダッシュボードには含める
+- [ ] 新しい順（`startAt DESC`）でソート
+- [ ] ダッシュボードページにカードを追加（`userType === 'user'` のみ表示）
+- [ ] 空状態（履歴なし）の表示
+- [ ] `ja.json` / `en.json` 両方に翻訳キーを追加
+- [ ] Playwright で動作確認（テストユーザーでログイン後に表示確認）

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -105,6 +105,11 @@
     "role_member": "Member",
     "go_to_org": "Go to Organization",
     "admin_link": "Admin Dashboard",
+    "organizer_history_title": "Organized Events",
+    "organizer_history_empty": "You haven't organized any events yet",
+    "event_status_published_ended": "Completed",
+    "event_status_cancelled": "Cancelled",
+    "event_status_rejected": "Rejected",
     "org": {
       "title": "Organization Dashboard",
       "back": "Back to Dashboard",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -105,6 +105,11 @@
     "role_member": "メンバー",
     "go_to_org": "組織ダッシュボードへ",
     "admin_link": "管理者画面へ",
+    "organizer_history_title": "主催イベント履歴",
+    "organizer_history_empty": "主催したイベントはまだありません",
+    "event_status_published_ended": "完了",
+    "event_status_cancelled": "キャンセル",
+    "event_status_rejected": "却下",
     "org": {
       "title": "組織ダッシュボード",
       "back": "ダッシュボードへ戻る",

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { db } from "@/lib/db";
 import { operatorApplications } from "@e-be/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
 import { EventCalendar } from "@/components/event-calendar";
-import { getEventsForCalendar } from "@/lib/events";
+import { getEventsForCalendar, getOrganizerHistory } from "@/lib/events";
 
 const USER_TYPE_VARIANT = {
   user: "secondary",
@@ -37,21 +37,26 @@ export default async function DashboardPage() {
     getEventsForCalendar({ from: calendarFrom, to: calendarTo }),
   ]);
 
-  // 申請中かどうかを確認（userType === 'user' の場合のみ）
+  // userType === 'user' のみ必要なデータを並行取得
   let hasPendingApplication = false;
+  let organizerHistory: Awaited<ReturnType<typeof getOrganizerHistory>> = [];
   if (userType === "user") {
-    const pending = await db
-      .select({ id: operatorApplications.id })
-      .from(operatorApplications)
-      .where(
-        and(
-          eq(operatorApplications.userId, user.id),
-          eq(operatorApplications.status, "pending"),
-          isNull(operatorApplications.deletedAt)
+    const [pendingResult, historyResult] = await Promise.all([
+      db
+        .select({ id: operatorApplications.id })
+        .from(operatorApplications)
+        .where(
+          and(
+            eq(operatorApplications.userId, user.id),
+            eq(operatorApplications.status, "pending"),
+            isNull(operatorApplications.deletedAt)
+          )
         )
-      )
-      .limit(1);
-    hasPendingApplication = pending.length > 0;
+        .limit(1),
+      getOrganizerHistory(user.id),
+    ]);
+    hasPendingApplication = pendingResult.length > 0;
+    organizerHistory = historyResult;
   }
 
   async function signOut() {
@@ -103,6 +108,60 @@ export default async function DashboardPage() {
             />
           </CardContent>
         </Card>
+
+        {userType === "user" && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("organizer_history_title")}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {organizerHistory.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  {t("organizer_history_empty")}
+                </p>
+              ) : (
+                <ul className="divide-y">
+                  {organizerHistory.map((event) => {
+                    const statusKey =
+                      event.status === "cancelled"
+                        ? "event_status_cancelled"
+                        : event.status === "rejected"
+                          ? "event_status_rejected"
+                          : "event_status_published_ended";
+                    return (
+                      <li key={event.id} className="flex items-center justify-between gap-3 py-3">
+                        <div className="min-w-0">
+                          <p className="truncate font-medium">
+                            {event.title ?? "—"}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {event.startAt
+                              ? new Date(event.startAt).toLocaleDateString(locale, {
+                                  year: "numeric",
+                                  month: "short",
+                                  day: "numeric",
+                                })
+                              : "—"}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={
+                            event.status === "cancelled" || event.status === "rejected"
+                              ? "secondary"
+                              : "outline"
+                          }
+                          className="shrink-0"
+                        >
+                          {t(statusKey)}
+                        </Badge>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader>

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { events } from "@e-be/db/schema";
-import { eq, and, gte, lte, isNull } from "drizzle-orm";
+import { eq, and, gte, lte, isNull, or, lt, desc } from "drizzle-orm";
 
 export type CalendarEventData = {
   id: string;
@@ -48,5 +48,58 @@ export async function getEventsForCalendar({
     id: row.id,
     title: row.title,
     startAt: row.startAt?.toISOString() ?? null,
+  }));
+}
+
+export type OrganizerHistoryItem = {
+  id: string;
+  title: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  status: string;
+  orgId: string;
+};
+
+/**
+ * ユーザーが主催したイベントの履歴を取得する。
+ * - completed 相当: published かつ endAt が過去（completed ステータスはスキーマに存在しない）
+ * - 自分のダッシュボード用に cancelled / rejected も含める
+ * - 新しい順（startAt DESC）で返す
+ */
+export async function getOrganizerHistory(userId: string): Promise<OrganizerHistoryItem[]> {
+  const now = new Date();
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      endAt: events.endAt,
+      status: events.status,
+      orgId: events.orgId,
+    })
+    .from(events)
+    .where(
+      and(
+        eq(events.userId, userId),
+        isNull(events.deletedAt),
+        or(
+          // completed 相当: published かつ終了済み
+          and(eq(events.status, "published"), lt(events.endAt, now)),
+          // 自分のダッシュボードのみ表示
+          eq(events.status, "cancelled"),
+          eq(events.status, "rejected")
+        )
+      )
+    )
+    .orderBy(desc(events.startAt));
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    startAt: row.startAt?.toISOString() ?? null,
+    endAt: row.endAt?.toISOString() ?? null,
+    status: row.status,
+    orgId: row.orgId,
   }));
 }


### PR DESCRIPTION
## 概要

一般ユーザー（イベンター）のダッシュボードに、過去に主催したイベントの履歴カードを追加する。

## 変更内容

- `apps/web/src/lib/events.ts`: `getOrganizerHistory()` 関数を追加
  - `published` + `endAt < now`（完了相当）/ `cancelled` / `rejected` を取得
  - `startAt DESC` 新しい順で返却
- `apps/web/src/app/[locale]/dashboard/page.tsx`: 主催履歴カードを追加（`userType === "user"` のみ表示）
- `apps/web/messages/ja.json` / `en.json`: 翻訳キーを追加

## 関連 Issue

Closes #15

## 確認方法

- [ ] `test-user@e-be.internal` でサインインし、ダッシュボードに「主催イベント履歴」カードが表示される
- [ ] 履歴がない場合「主催したイベントはまだありません」が表示される
- [ ] `test-venue@e-be.internal`（事業者）では履歴カードが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)