### PR TITLE
feat: ダッシュボードに参加予定イベントセクションを追加し参加履歴の表示ロジックを変更

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -151,7 +151,9 @@
     "participation_history_title": "Events I Joined",
     "participation_history_empty": "You have not joined any events yet",
     "participation_status_registered": "Registered",
-    "participation_status_cancelled": "Cancelled"
+    "participation_status_cancelled": "Cancelled",
+    "upcoming_participations_title": "Upcoming Events",
+    "upcoming_participations_empty": "No upcoming events."
   },
   "apply": {
     "title": "Venue Operator Application",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -151,7 +151,9 @@
     "participation_history_title": "参加イベント履歴",
     "participation_history_empty": "参加したイベントはまだありません",
     "participation_status_registered": "参加予定",
-    "participation_status_cancelled": "キャンセル済み"
+    "participation_status_cancelled": "キャンセル済み",
+    "upcoming_participations_title": "参加予定イベント",
+    "upcoming_participations_empty": "参加予定のイベントはありません"
   },
   "apply": {
     "title": "事業者申請",

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { db } from "@/lib/db";
 import { operatorApplications } from "@e-be/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
 import { EventCalendar } from "@/components/event-calendar";
-import { getEventsForCalendar, getOrganizerHistory, getParticipationHistory } from "@/lib/events";
+import { getEventsForCalendar, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations } from "@/lib/events";
 
 const USER_TYPE_VARIANT = {
   user: "secondary",
@@ -37,8 +37,9 @@ export default async function DashboardPage() {
   let hasPendingApplication = false;
   let organizerHistory: Awaited<ReturnType<typeof getOrganizerHistory>> = [];
   let participationHistory: Awaited<ReturnType<typeof getParticipationHistory>> = [];
+  let upcomingParticipations: Awaited<ReturnType<typeof getUpcomingParticipations>> = [];
   if (userType === "user") {
-    const [pendingResult, historyResult, participationResult] = await Promise.all([
+    const [pendingResult, historyResult, participationResult, upcomingResult] = await Promise.all([
       db
         .select({ id: operatorApplications.id })
         .from(operatorApplications)
@@ -52,10 +53,12 @@ export default async function DashboardPage() {
         .limit(1),
       getOrganizerHistory(user.id),
       getParticipationHistory(user.id),
+      getUpcomingParticipations(user.id),
     ]);
     hasPendingApplication = pendingResult.length > 0;
     organizerHistory = historyResult;
     participationHistory = participationResult;
+    upcomingParticipations = upcomingResult;
   }
 
   const userTypeKey = `user_type_${userType}` as const;
@@ -83,6 +86,48 @@ export default async function DashboardPage() {
             />
           </CardContent>
         </Card>
+
+        {userType === "user" && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("upcoming_participations_title")}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {upcomingParticipations.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  {t("upcoming_participations_empty")}
+                </p>
+              ) : (
+                <ul className="divide-y">
+                  {upcomingParticipations.map((item) => (
+                    <li key={item.participationId}>
+                      <Link
+                        href={`/${locale}/dashboard/event/${item.eventId}`}
+                        className="flex items-center justify-between gap-3 py-3 hover:bg-muted/50 -mx-2 px-2 rounded-md transition-colors"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate font-medium">{item.title ?? "—"}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {item.startAt
+                              ? new Date(item.startAt).toLocaleDateString(locale, {
+                                  year: "numeric",
+                                  month: "short",
+                                  day: "numeric",
+                                })
+                              : "—"}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className="shrink-0">
+                          {t("participation_status_registered")}
+                        </Badge>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         {userType === "user" && (
           <Card>

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { events, eventParticipations } from "@e-be/db/schema";
-import { eq, and, gte, lte, isNull, or, lt, desc } from "drizzle-orm";
+import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc } from "drizzle-orm";
 
 export type CalendarEventData = {
   id: string;
@@ -114,12 +114,61 @@ export type ParticipationHistoryItem = {
   eventStatus: string;
 };
 
+export type UpcomingParticipationItem = {
+  participationId: string;
+  eventId: string;
+  title: string | null;
+  startAt: string | null;
+  endAt: string | null;
+};
+
+/**
+ * 参加予定のイベントを取得する。
+ * - registered かつ events.endAt が未来のもの
+ * - 近い順（events.startAt ASC）で返す
+ */
+export async function getUpcomingParticipations(userId: string): Promise<UpcomingParticipationItem[]> {
+  const now = new Date();
+
+  const rows = await db
+    .select({
+      participationId: eventParticipations.id,
+      eventId: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      endAt: events.endAt,
+    })
+    .from(eventParticipations)
+    .innerJoin(events, eq(eventParticipations.eventId, events.id))
+    .where(
+      and(
+        eq(eventParticipations.userId, userId),
+        eq(eventParticipations.status, "registered"),
+        isNull(eventParticipations.deletedAt),
+        isNull(events.deletedAt),
+        gt(events.endAt, now)
+      )
+    )
+    .orderBy(asc(events.startAt));
+
+  return rows.map((row) => ({
+    participationId: row.participationId,
+    eventId: row.eventId,
+    title: row.title,
+    startAt: row.startAt?.toISOString() ?? null,
+    endAt: row.endAt?.toISOString() ?? null,
+  }));
+}
+
 /**
  * ユーザーが参加表明したイベントの履歴を取得する。
+ * - registered かつ endAt が過去、または cancelled
  * - 論理削除されていない参加レコードのみ
  * - 新しい順（events.startAt DESC）で返す
  */
 export async function getParticipationHistory(userId: string): Promise<ParticipationHistoryItem[]> {
+  const now = new Date();
+
   const rows = await db
     .select({
       participationId: eventParticipations.id,
@@ -136,7 +185,11 @@ export async function getParticipationHistory(userId: string): Promise<Participa
       and(
         eq(eventParticipations.userId, userId),
         isNull(eventParticipations.deletedAt),
-        isNull(events.deletedAt)
+        isNull(events.deletedAt),
+        or(
+          and(eq(eventParticipations.status, "registered"), lt(events.endAt, now)),
+          eq(eventParticipations.status, "cancelled")
+        )
       )
     )
     .orderBy(desc(events.startAt));


### PR DESCRIPTION
## 概要

「参加予定」のイベントを履歴セクションから分離し、専用の「参加予定イベント」セクションを追加。
参加予定イベントはクリックでイベント詳細ページへ遷移できるようにした。

## 変更内容

- `events.ts` に `getUpcomingParticipations` を追加（registered + endAt > now、ASC）
- `getParticipationHistory` を変更（registered + endAt < now、または cancelled のみ返す）
- ダッシュボードに「参加予定イベント」カードを追加（主催履歴の上に配置）
- 参加予定カードの各アイテムを `/dashboard/event/[eventId]` へのリンクに変更
- ja.json / en.json に `upcoming_participations_title` / `upcoming_participations_empty` キーを追加

## 関連 Issue

Closes #21

## 確認方法

- [ ] 一般ユーザー（test-user@e-be.internal）でダッシュボードにアクセスする
- [ ] 「参加予定イベント」セクションが主催履歴の上に表示されること
- [ ] 参加予定イベントがある場合はリンク付きで表示され、クリックで詳細ページへ遷移すること
- [ ] 「参加イベント履歴」には完了 or キャンセルのイベントのみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)