### PR TITLE
feat: イベント詳細ページを実装 — /dashboard/event/[eventId]

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -204,5 +204,16 @@
   "metadata": {
     "title": "E-be",
     "description": "The event bar management platform connecting venues and organizers"
+  },
+  "event_detail": {
+    "back": "Back to Dashboard",
+    "start_at": "Starts",
+    "end_at": "Ends",
+    "location": "Location",
+    "organizer": "Organizer",
+    "my_status": "My Status",
+    "not_found": "Event not found",
+    "status_registered": "Registered",
+    "status_cancelled": "Cancelled"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -204,5 +204,16 @@
   "metadata": {
     "title": "イーベ (E-be)",
     "description": "良いイベントを増やす、店舗と主催者をつなぐイベントバー運営プラットフォーム"
+  },
+  "event_detail": {
+    "back": "ダッシュボードへ戻る",
+    "start_at": "開催開始",
+    "end_at": "開催終了",
+    "location": "開催場所",
+    "organizer": "主催",
+    "my_status": "参加ステータス",
+    "not_found": "イベントが見つかりません",
+    "status_registered": "参加予定",
+    "status_cancelled": "キャンセル済み"
   }
 }

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -1,0 +1,93 @@
+import { notFound } from "next/navigation";
+import { getTranslations, getLocale } from "next-intl/server";
+import { getUser } from "@/lib/auth";
+import { getEventDetail } from "@/lib/events";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+
+type Props = {
+  params: Promise<{ eventId: string }>;
+};
+
+export default async function EventDetailPage({ params }: Props) {
+  const { eventId } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("event_detail");
+
+  const user = await getUser();
+  if (!user) notFound();
+
+  const event = await getEventDetail(eventId, user.id);
+  if (!event) notFound();
+
+  const formatDate = (iso: string | null) => {
+    if (!iso) return "—";
+    return new Date(iso).toLocaleString(locale, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <main className="p-4 md:p-6">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div>
+          <Link
+            href={`/${locale}/dashboard`}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            ← {t("back")}
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">{event.title ?? "—"}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <dl className="space-y-3">
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("start_at")}</dt>
+                <dd className="text-sm font-medium">{formatDate(event.startAt)}</dd>
+              </div>
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("end_at")}</dt>
+                <dd className="text-sm font-medium">{formatDate(event.endAt)}</dd>
+              </div>
+              {event.location && (
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("location")}</dt>
+                  <dd className="text-sm font-medium">{event.location}</dd>
+                </div>
+              )}
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("organizer")}</dt>
+                <dd className="text-sm font-medium">{event.orgName}</dd>
+              </div>
+              {event.myParticipationStatus && (
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("my_status")}</dt>
+                  <dd>
+                    <Badge
+                      variant={
+                        event.myParticipationStatus === "cancelled" ? "secondary" : "outline"
+                      }
+                    >
+                      {event.myParticipationStatus === "cancelled"
+                        ? t("status_cancelled")
+                        : t("status_registered")}
+                    </Badge>
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { events, eventParticipations } from "@e-be/db/schema";
+import { events, eventParticipations, organizations } from "@e-be/db/schema";
 import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc } from "drizzle-orm";
 
 export type CalendarEventData = {
@@ -203,4 +203,66 @@ export async function getParticipationHistory(userId: string): Promise<Participa
     endAt: row.endAt?.toISOString() ?? null,
     eventStatus: row.eventStatus,
   }));
+}
+
+export type EventDetail = {
+  id: string;
+  title: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  location: string | null;
+  orgName: string;
+  myParticipationStatus: "registered" | "cancelled" | null;
+};
+
+/**
+ * イベント詳細を取得する。
+ * - published かつ deleted_at IS NULL のイベントのみ
+ * - userId が一致する参加レコードがあれば参加ステータスも返す
+ */
+export async function getEventDetail(
+  eventId: string,
+  userId: string
+): Promise<EventDetail | null> {
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      endAt: events.endAt,
+      location: events.location,
+      orgName: organizations.name,
+      participationStatus: eventParticipations.status,
+    })
+    .from(events)
+    .innerJoin(organizations, eq(events.orgId, organizations.id))
+    .leftJoin(
+      eventParticipations,
+      and(
+        eq(eventParticipations.eventId, events.id),
+        eq(eventParticipations.userId, userId),
+        isNull(eventParticipations.deletedAt)
+      )
+    )
+    .where(
+      and(
+        eq(events.id, eventId),
+        eq(events.status, "published"),
+        isNull(events.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+
+  const row = rows[0];
+  return {
+    id: row.id,
+    title: row.title,
+    startAt: row.startAt?.toISOString() ?? null,
+    endAt: row.endAt?.toISOString() ?? null,
+    location: row.location,
+    orgName: row.orgName,
+    myParticipationStatus: row.participationStatus ?? null,
+  };
 }


### PR DESCRIPTION
## 概要

参加予定セクション（#21）からリンクされるイベント詳細ページを実装。
認証済みユーザーがイベントの基本情報と自分の参加ステータスを確認できる。

## 変更内容

- `events.ts` に `getEventDetail(eventId, userId)` を追加
  - events JOIN organizations（バー名取得）
  - LEFT JOIN eventParticipations（参加ステータス取得）
  - published + deleted_at IS NULL のみ対象
- `/[locale]/dashboard/event/[eventId]/page.tsx` を新規作成
  - 存在しない eventId → `notFound()`（404）
  - タイトル・開催日時・場所・主催バー名・参加ステータスを表示
  - location が null の場合は非表示
  - 「← ダッシュボードへ戻る」リンク付き
- ja.json / en.json に `event_detail.*` 翻訳キーを追加

## 関連 Issue

Closes #22

## 確認方法

- [ ] 一般ユーザーでサインインし、参加イベント履歴のイベントに直接 URL でアクセス
- [ ] イベント情報（タイトル・日時・主催）が表示されること
- [ ] 参加ステータスが正しく表示されること（参加予定 / キャンセル済み）
- [ ] 存在しない eventId で 404 になること
- [ ] 「← ダッシュボードへ戻る」でダッシュボードに遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)