### PR TITLE
feat: 参加予定イベントのサンプルデータ追加とイベント詳細ページ改善

### DIFF
--- a/apps/web/scripts/seed-test-accounts.mjs
+++ b/apps/web/scripts/seed-test-accounts.mjs
@@ -197,6 +197,24 @@ async function upsertTestEventsAndParticipations(testUserId, orgId) {
       endAt:   new Date('2026-01-10T21:00:00Z'),
       participationStatus: 'registered',
     },
+    {
+      title: '【テスト】春のカクテルナイト',
+      startAt: new Date('2026-04-05T18:00:00Z'),
+      endAt:   new Date('2026-04-05T22:00:00Z'),
+      participationStatus: 'registered',
+    },
+    {
+      title: '【テスト】ゴールデンウィーク特別イベント',
+      startAt: new Date('2026-05-03T17:00:00Z'),
+      endAt:   new Date('2026-05-03T23:00:00Z'),
+      participationStatus: 'registered',
+    },
+    {
+      title: '【テスト】初夏のビアガーデン',
+      startAt: new Date('2026-06-20T16:00:00Z'),
+      endAt:   new Date('2026-06-20T21:00:00Z'),
+      participationStatus: 'registered',
+    },
   ];
 
   for (const ev of TEST_EVENTS) {

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
 import { getUser } from "@/lib/auth";
 import { getEventDetail } from "@/lib/events";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 
@@ -21,72 +21,136 @@ export default async function EventDetailPage({ params }: Props) {
   const event = await getEventDetail(eventId, user.id);
   if (!event) notFound();
 
-  const formatDate = (iso: string | null) => {
-    if (!iso) return "—";
-    return new Date(iso).toLocaleString(locale, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
+  const formatDate = (iso: string | null) =>
+    iso
+      ? new Date(iso).toLocaleDateString(locale, {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          weekday: "short",
+        })
+      : null;
+
+  const formatTime = (iso: string | null) =>
+    iso
+      ? new Date(iso).toLocaleTimeString(locale, {
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : null;
+
+  const isRegistered = event.myParticipationStatus === "registered";
+  const isCancelled = event.myParticipationStatus === "cancelled";
+
+  const startDate = formatDate(event.startAt);
+  const startTime = formatTime(event.startAt);
+  const endDate = formatDate(event.endAt);
+  const endTime = formatTime(event.endAt);
+  const isSameDay = startDate && endDate && startDate === endDate;
 
   return (
     <main className="p-4 md:p-6">
-      <div className="mx-auto max-w-2xl space-y-6">
-        <div>
-          <Link
-            href={`/${locale}/dashboard`}
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            ← {t("back")}
-          </Link>
+      <div className="mx-auto max-w-2xl space-y-5">
+
+        {/* 戻るリンク */}
+        <Link
+          href={`/${locale}/dashboard`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <span aria-hidden>←</span>
+          {t("back")}
+        </Link>
+
+        {/* タイトル + ステータス */}
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <h1 className="text-2xl font-bold leading-tight">{event.title ?? "—"}</h1>
+            {event.myParticipationStatus && (
+              <Badge
+                variant={isCancelled ? "secondary" : "default"}
+                className="shrink-0 mt-1"
+              >
+                {isCancelled ? t("status_cancelled") : t("status_registered")}
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">{event.orgName}</p>
         </div>
 
+        {/* 日時カード */}
         <Card>
-          <CardHeader>
-            <CardTitle className="text-xl">{event.title ?? "—"}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <dl className="space-y-3">
-              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("start_at")}</dt>
-                <dd className="text-sm font-medium">{formatDate(event.startAt)}</dd>
+          <CardContent className="pt-5 pb-5 space-y-4">
+            <div className={isSameDay ? "space-y-3" : "grid grid-cols-2 gap-4"}>
+              {/* 開始 */}
+              <div className="space-y-0.5">
+                <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t("start_at")}
+                </p>
+                <p className="text-sm text-muted-foreground">{startDate ?? "—"}</p>
+                {startTime && (
+                  <p className="text-3xl font-bold tabular-nums">{startTime}</p>
+                )}
               </div>
-              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("end_at")}</dt>
-                <dd className="text-sm font-medium">{formatDate(event.endAt)}</dd>
+
+              {/* 終了 */}
+              <div className="space-y-0.5">
+                <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                  {t("end_at")}
+                </p>
+                {!isSameDay && (
+                  <p className="text-sm text-muted-foreground">{endDate ?? "—"}</p>
+                )}
+                {endTime && (
+                  <p className="text-3xl font-bold tabular-nums">{endTime}</p>
+                )}
               </div>
-              {event.location && (
-                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-                  <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("location")}</dt>
-                  <dd className="text-sm font-medium">{event.location}</dd>
+            </div>
+
+            {/* 場所 */}
+            {event.location && (
+              <>
+                <div className="border-t border-border" />
+                <div className="space-y-0.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                    {t("location")}
+                  </p>
+                  <p className="font-medium">{event.location}</p>
                 </div>
-              )}
-              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-                <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("organizer")}</dt>
-                <dd className="text-sm font-medium">{event.orgName}</dd>
-              </div>
-              {event.myParticipationStatus && (
-                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-                  <dt className="w-24 shrink-0 text-sm text-muted-foreground">{t("my_status")}</dt>
-                  <dd>
-                    <Badge
-                      variant={
-                        event.myParticipationStatus === "cancelled" ? "secondary" : "outline"
-                      }
-                    >
-                      {event.myParticipationStatus === "cancelled"
-                        ? t("status_cancelled")
-                        : t("status_registered")}
-                    </Badge>
-                  </dd>
-                </div>
-              )}
-            </dl>
+              </>
+            )}
           </CardContent>
         </Card>
+
+        {/* 参加ステータスカード */}
+        {event.myParticipationStatus && (
+          <Card
+            className={
+              isRegistered
+                ? "border-green-500/40 bg-green-500/5"
+                : "border-border"
+            }
+          >
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="space-y-0.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                    {t("my_status")}
+                  </p>
+                  <p className="font-semibold">
+                    {isRegistered ? t("status_registered") : t("status_cancelled")}
+                  </p>
+                </div>
+                <span
+                  className={`text-2xl ${isRegistered ? "text-green-500" : "text-muted-foreground"}`}
+                  aria-hidden
+                >
+                  {isRegistered ? "✓" : "✕"}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
       </div>
     </main>
   );

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -201,27 +201,32 @@ export default async function DashboardPage() {
                         ? "participation_status_cancelled"
                         : "participation_status_registered";
                     return (
-                      <li key={item.participationId} className="flex items-center justify-between gap-3 py-3">
-                        <div className="min-w-0">
-                          <p className="truncate font-medium">
-                            {item.title ?? "—"}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {item.startAt
-                              ? new Date(item.startAt).toLocaleDateString(locale, {
-                                  year: "numeric",
-                                  month: "short",
-                                  day: "numeric",
-                                })
-                              : "—"}
-                          </p>
-                        </div>
-                        <Badge
-                          variant={item.participationStatus === "cancelled" ? "secondary" : "outline"}
-                          className="shrink-0"
+                      <li key={item.participationId}>
+                        <Link
+                          href={`/${locale}/dashboard/event/${item.eventId}`}
+                          className="flex items-center justify-between gap-3 py-3 hover:bg-muted/50 -mx-2 px-2 rounded-md transition-colors"
                         >
-                          {t(statusKey)}
-                        </Badge>
+                          <div className="min-w-0">
+                            <p className="truncate font-medium">
+                              {item.title ?? "—"}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {item.startAt
+                                ? new Date(item.startAt).toLocaleDateString(locale, {
+                                    year: "numeric",
+                                    month: "short",
+                                    day: "numeric",
+                                  })
+                                : "—"}
+                            </p>
+                          </div>
+                          <Badge
+                            variant={item.participationStatus === "cancelled" ? "secondary" : "outline"}
+                            className="shrink-0"
+                          >
+                            {t(statusKey)}
+                          </Badge>
+                        </Link>
                       </li>
                     );
                   })}


### PR DESCRIPTION
## 概要

- 参加予定セクションに「参加予定のイベントはありません」と表示され続ける問題を解消
- イベント詳細ページのデザインを全面改修

## 変更内容

### サンプルデータ追加（`seed-test-accounts.mjs`）
- 未来日程の参加予定イベント3件を追加（春・GW・初夏）
- 既存の2025年イベントはすべて現在日（2026-03-20）より過去のため `getUpcomingParticipations` に表示されなかった

### ダッシュボード改善（`dashboard/page.tsx`）
- 参加履歴の各アイテムにイベント詳細ページへの `<Link>` を追加
  - 参加予定セクションは既にリンク済みだったが、参加履歴は未対応だった

### イベント詳細ページ全面改修（`event/[eventId]/page.tsx`）
- タイトルをカード外に `text-2xl font-bold` で大きく表示
- ステータスバッジをタイトル行に配置（スクロール前に確認できる）
- 主催者名をタイトル直下のサブテキストとして表示
- 日時を「日付(sm) + 時刻(text-3xl)」の2段組みで視認性向上
- 同日イベントは縦並び表示（開始 → 終了）に最適化
- 参加ステータスを独立カードで表示（registered: 緑背景 + ✓）

## テスト方法

1. `pnpm seed:test` でサンプルデータを作成（初回のみ）
2. `test-user@e-be.internal / testpass2026` でサインイン
3. ダッシュボードの「参加予定イベント」に3件表示されることを確認
4. 各イベントをタップしてイベント詳細ページへ遷移することを確認
5. 参加履歴のアイテムもリンクになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)