### PR TITLE
feat: 退会処理機能を実装 (#7)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -153,7 +153,24 @@
     "participation_status_registered": "Registered",
     "participation_status_cancelled": "Cancelled",
     "upcoming_participations_title": "Upcoming Events",
-    "upcoming_participations_empty": "No upcoming events."
+    "upcoming_participations_empty": "No upcoming events.",
+    "account_settings": {
+      "title": "Account Settings",
+      "withdrawal_section_title": "Delete Account",
+      "withdrawal_description": "Deleting your account will permanently remove your account and all associated data. This action cannot be undone.",
+      "withdrawal_button": "Delete Account",
+      "withdrawal_confirm_title": "Confirm Account Deletion",
+      "withdrawal_confirm_description": "To confirm, type \"Delete\" in the field below.",
+      "withdrawal_confirm_placeholder": "Delete",
+      "withdrawal_confirm_submit": "Permanently Delete Account",
+      "withdrawal_confirm_cancel": "Cancel",
+      "withdrawal_checking": "Checking...",
+      "withdrawal_processing": "Processing...",
+      "blocker_owner_title": "You own an organization",
+      "blocker_owner_description": "Before deleting your account, please transfer ownership of your organizations to another member or delete them.",
+      "blocker_event_title": "You have active events",
+      "blocker_event_description": "Before deleting your account, please cancel all upcoming published events."
+    }
   },
   "apply": {
     "title": "Venue Operator Application",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -153,7 +153,24 @@
     "participation_status_registered": "参加予定",
     "participation_status_cancelled": "キャンセル済み",
     "upcoming_participations_title": "参加予定イベント",
-    "upcoming_participations_empty": "参加予定のイベントはありません"
+    "upcoming_participations_empty": "参加予定のイベントはありません",
+    "account_settings": {
+      "title": "アカウント設定",
+      "withdrawal_section_title": "退会",
+      "withdrawal_description": "退会すると、アカウントと関連データが削除されます。この操作は取り消せません。",
+      "withdrawal_button": "退会する",
+      "withdrawal_confirm_title": "退会の確認",
+      "withdrawal_confirm_description": "退会を確定するには、下のフィールドに「退会する」と入力してください。",
+      "withdrawal_confirm_placeholder": "退会する",
+      "withdrawal_confirm_submit": "退会を確定する",
+      "withdrawal_confirm_cancel": "キャンセル",
+      "withdrawal_checking": "確認中...",
+      "withdrawal_processing": "退会処理中...",
+      "blocker_owner_title": "組織のオーナーです",
+      "blocker_owner_description": "退会前に、所有している組織のオーナー権限を他のメンバーに移譲するか、組織を削除してください。",
+      "blocker_event_title": "公開中のイベントがあります",
+      "blocker_event_description": "退会前に、開催中・今後予定されているすべてのイベントをキャンセルしてください。"
+    }
   },
   "apply": {
     "title": "事業者申請",

--- a/apps/web/src/app/[locale]/dashboard/layout.tsx
+++ b/apps/web/src/app/[locale]/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
-import { getUser, getUserType } from "@/lib/auth";
+import { getUser, getDbUser, getUserType } from "@/lib/auth";
 import { AppHeader } from "@/components/layout/app-header";
 import { AppFooter } from "@/components/layout/app-footer";
 
@@ -9,9 +9,9 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [locale, user] = await Promise.all([getLocale(), getUser()]);
+  const [locale, user, dbUser] = await Promise.all([getLocale(), getUser(), getDbUser()]);
 
-  if (!user) {
+  if (!user || !dbUser) {
     redirect(`/${locale}/auth/sign-in`);
   }
 

--- a/apps/web/src/app/[locale]/dashboard/settings/actions.ts
+++ b/apps/web/src/app/[locale]/dashboard/settings/actions.ts
@@ -1,0 +1,30 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { getLocale } from 'next-intl/server';
+import { getUser, getDbUser } from '@/lib/auth';
+import { checkWithdrawalBlockers, withdrawUser } from '@/lib/withdrawal';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+export async function checkWithdrawalAction() {
+  const [authUser, dbUser] = await Promise.all([getUser(), getDbUser()]);
+  if (!authUser || !dbUser) return { error: 'unauthorized' as const };
+
+  const blockers = await checkWithdrawalBlockers(dbUser.id);
+  return { blockers };
+}
+
+export async function withdrawAction() {
+  const locale = await getLocale();
+  const [authUser, dbUser] = await Promise.all([getUser(), getDbUser()]);
+  if (!authUser || !dbUser) redirect(`/${locale}/auth/sign-in`);
+
+  // DB 退会処理
+  await withdrawUser(dbUser.id);
+
+  // Supabase Auth ユーザー削除
+  const adminClient = createAdminClient();
+  await adminClient.auth.admin.deleteUser(authUser.id);
+
+  redirect(`/${locale}`);
+}

--- a/apps/web/src/app/[locale]/dashboard/settings/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/settings/page.tsx
@@ -1,0 +1,13 @@
+import { getTranslations } from 'next-intl/server';
+import { WithdrawalSection } from './withdrawal-section';
+
+export default async function AccountSettingsPage() {
+  const t = await getTranslations('dashboard.account_settings');
+
+  return (
+    <main className="container mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">{t('title')}</h1>
+      <WithdrawalSection />
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/settings/withdrawal-section.tsx
+++ b/apps/web/src/app/[locale]/dashboard/settings/withdrawal-section.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { checkWithdrawalAction, withdrawAction } from './actions';
+
+type Blocker = { type: 'owner' | 'published_event'; message: string };
+
+type Step =
+  | { name: 'idle' }
+  | { name: 'checking' }
+  | { name: 'blocked'; blockers: Blocker[] }
+  | { name: 'confirm' }
+  | { name: 'processing' };
+
+export function WithdrawalSection() {
+  const t = useTranslations('dashboard.account_settings');
+  const [step, setStep] = useState<Step>({ name: 'idle' });
+  const [confirmText, setConfirmText] = useState('');
+
+  const confirmKeyword = t('withdrawal_confirm_placeholder');
+
+  async function handleWithdrawalClick() {
+    setStep({ name: 'checking' });
+    const result = await checkWithdrawalAction();
+
+    if ('error' in result) {
+      setStep({ name: 'idle' });
+      return;
+    }
+
+    if (result.blockers.length > 0) {
+      setStep({ name: 'blocked', blockers: result.blockers });
+      return;
+    }
+
+    setStep({ name: 'confirm' });
+  }
+
+  async function handleConfirmSubmit() {
+    if (confirmText !== confirmKeyword) return;
+    setStep({ name: 'processing' });
+    await withdrawAction();
+  }
+
+  return (
+    <Card className="border-destructive">
+      <CardHeader>
+        <CardTitle className="text-destructive">{t('withdrawal_section_title')}</CardTitle>
+        <CardDescription>{t('withdrawal_description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {step.name === 'idle' && (
+          <Button
+            variant="destructive"
+            className="min-h-11 cursor-pointer"
+            onClick={handleWithdrawalClick}
+          >
+            {t('withdrawal_button')}
+          </Button>
+        )}
+
+        {step.name === 'checking' && (
+          <Button variant="destructive" className="min-h-11" disabled>
+            {t('withdrawal_checking')}
+          </Button>
+        )}
+
+        {step.name === 'blocked' && (
+          <div className="space-y-3">
+            {step.blockers.map((blocker) => (
+              <div
+                key={blocker.type}
+                className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800"
+              >
+                <p className="font-semibold">
+                  {blocker.type === 'owner'
+                    ? t('blocker_owner_title')
+                    : t('blocker_event_title')}
+                </p>
+                <p className="mt-1">
+                  {blocker.type === 'owner'
+                    ? t('blocker_owner_description')
+                    : t('blocker_event_description')}
+                </p>
+              </div>
+            ))}
+            <Button
+              variant="outline"
+              className="min-h-11 cursor-pointer"
+              onClick={() => setStep({ name: 'idle' })}
+            >
+              {t('withdrawal_confirm_cancel')}
+            </Button>
+          </div>
+        )}
+
+        {step.name === 'confirm' && (
+          <div className="space-y-4">
+            <div>
+              <p className="mb-2 text-sm font-semibold">{t('withdrawal_confirm_title')}</p>
+              <p className="mb-4 text-sm text-muted-foreground">
+                {t('withdrawal_confirm_description')}
+              </p>
+              <Label htmlFor="confirm-text" className="mb-1 block text-sm">
+                {confirmKeyword}
+              </Label>
+              <Input
+                id="confirm-text"
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={confirmKeyword}
+                className="max-w-xs"
+              />
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                variant="destructive"
+                className="min-h-11 cursor-pointer"
+                disabled={confirmText !== confirmKeyword}
+                onClick={handleConfirmSubmit}
+              >
+                {t('withdrawal_confirm_submit')}
+              </Button>
+              <Button
+                variant="outline"
+                className="min-h-11 cursor-pointer"
+                onClick={() => {
+                  setConfirmText('');
+                  setStep({ name: 'idle' });
+                }}
+              >
+                {t('withdrawal_confirm_cancel')}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step.name === 'processing' && (
+          <Button variant="destructive" className="min-h-11" disabled>
+            {t('withdrawal_processing')}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -15,6 +15,27 @@ export const getUser = cache(async () => {
   return user ?? null;
 });
 
+/** DB上の users レコードを取得（email で JOIN、deleted_at IS NULL 条件付き）
+ *  React.cache() により同一リクエスト内で複数回呼ばれても DB 問い合わせは1回のみ
+ */
+export const getDbUser = cache(async () => {
+  const authUser = await getUser();
+  if (!authUser?.email) return null;
+
+  const rows = await db
+    .select()
+    .from(users)
+    .where(
+      and(
+        eq(users.email, authUser.email),
+        isNull(users.deletedAt)
+      )
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+});
+
 /** 指定組織でのロールを取得（非メンバーなら null） */
 export async function getOrgRole(
   userId: string,

--- a/apps/web/src/lib/withdrawal.ts
+++ b/apps/web/src/lib/withdrawal.ts
@@ -1,0 +1,128 @@
+import { and, eq, gt, isNull } from 'drizzle-orm';
+import { db } from './db';
+import {
+  users,
+  organizationMembers,
+  barHostPermissions,
+  events,
+  auditLogs,
+} from '@e-be/db/schema';
+
+export type WithdrawalBlocker =
+  | { type: 'owner'; message: string }
+  | { type: 'published_event'; message: string };
+
+export async function checkWithdrawalBlockers(
+  userId: string
+): Promise<WithdrawalBlocker[]> {
+  const blockers: WithdrawalBlocker[] = [];
+
+  // owner チェック
+  const ownerRows = await db
+    .select({ id: organizationMembers.id })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.userId, userId),
+        eq(organizationMembers.role, 'owner'),
+        isNull(organizationMembers.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (ownerRows.length > 0) {
+    blockers.push({ type: 'owner', message: 'owner' });
+  }
+
+  // 公開中イベントチェック
+  const now = new Date();
+  const eventRows = await db
+    .select({ id: events.id })
+    .from(events)
+    .where(
+      and(
+        eq(events.userId, userId),
+        eq(events.status, 'published'),
+        gt(events.endAt, now)
+      )
+    )
+    .limit(1);
+
+  if (eventRows.length > 0) {
+    blockers.push({ type: 'published_event', message: 'published_event' });
+  }
+
+  return blockers;
+}
+
+export async function withdrawUser(dbUserId: string): Promise<void> {
+  const now = new Date();
+
+  await db.transaction(async (tx) => {
+    // ブロック条件の最終チェック（競合対策）
+    const [ownerCheck, eventCheck] = await Promise.all([
+      tx
+        .select({ id: organizationMembers.id })
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.userId, dbUserId),
+            eq(organizationMembers.role, 'owner'),
+            isNull(organizationMembers.deletedAt)
+          )
+        )
+        .limit(1),
+      tx
+        .select({ id: events.id })
+        .from(events)
+        .where(
+          and(
+            eq(events.userId, dbUserId),
+            eq(events.status, 'published'),
+            gt(events.endAt, now)
+          )
+        )
+        .limit(1),
+    ]);
+
+    if (ownerCheck.length > 0 || eventCheck.length > 0) {
+      throw new Error('BLOCKED');
+    }
+
+    // audit_log を先に insert（users.deleted_at 設定前）
+    await tx.insert(auditLogs).values({
+      userId: dbUserId,
+      action: 'user_withdrawn',
+      entityType: 'user',
+      entityId: dbUserId,
+    });
+
+    // organization_members の論理削除
+    await tx
+      .update(organizationMembers)
+      .set({ deletedAt: now })
+      .where(
+        and(
+          eq(organizationMembers.userId, dbUserId),
+          isNull(organizationMembers.deletedAt)
+        )
+      );
+
+    // bar_host_permissions の無効化
+    await tx
+      .update(barHostPermissions)
+      .set({ revokedAt: now })
+      .where(
+        and(
+          eq(barHostPermissions.userId, dbUserId),
+          isNull(barHostPermissions.revokedAt)
+        )
+      );
+
+    // users の論理削除
+    await tx
+      .update(users)
+      .set({ deletedAt: now })
+      .where(eq(users.id, dbUserId));
+  });
+}


### PR DESCRIPTION
## Summary

- `withdrawal.ts` を新規作成: `checkWithdrawalBlockers`（owner・公開イベントチェック）/ `withdrawUser`（DB トランザクション）
- `auth.ts` に `getDbUser()` を追加: email で DB ユーザーを取得し `deleted_at IS NULL` チェック
- `dashboard/layout.tsx`: 退会済みユーザーをサインインページへリダイレクト
- `/dashboard/settings` ページ新規作成: 退会フロー UI（ブロッカー表示 → 確認入力 → 退会実行）
- i18n 対応（ja / en）

## 退会フロー

1. 「退会する」ボタン押下 → Server Action でブロッカーチェック
2. ブロッカーあり（owner権限 / 公開中イベント）→ エラーメッセージ表示
3. ブロッカーなし → 確認フォーム表示（「退会する」と入力で送信ボタン活性化）
4. 送信 → DB トランザクション（audit_log → 組織メンバー削除 → bar_host_permissions 無効化 → users 論理削除）→ Supabase Auth ユーザー削除 → トップへリダイレクト

## Test plan

- [x] `/ja/dashboard/settings` が正常に表示される
- [x] 公開中イベントがあるユーザーは退会ブロックされる（Playwright で確認）
- [x] キャンセルで初期状態に戻る
- [x] TypeScript エラー 0 件
- [ ] ブロッカーなしユーザーで確認入力フロー → 実際の退会処理（手動テスト推奨）

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)