### PR TITLE
fix: 参加クエリに published フィルタ追加 + privacy ページに metadata 追加 (#24)

### DIFF
--- a/apps/web/src/app/[locale]/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/privacy/page.tsx
@@ -1,7 +1,21 @@
+import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 import { NavBar } from "@/components/lp/nav-bar";
 import { AppFooter } from "@/components/layout/app-footer";
 import { getUser } from "@/lib/auth";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "privacy" });
+  return {
+    title: t("title"),
+    description: t("introduction"),
+  };
+}
 
 export default async function PrivacyPage() {
   const [t, locale, user, homeT] = await Promise.all([

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -125,6 +125,7 @@ export type UpcomingParticipationItem = {
 /**
  * 参加予定のイベントを取得する。
  * - registered かつ events.endAt が未来のもの
+ * - events.status = 'published' のみ（cancelled/rejected イベントは表示しない）
  * - 近い順（events.startAt ASC）で返す
  */
 export async function getUpcomingParticipations(userId: string): Promise<UpcomingParticipationItem[]> {
@@ -146,7 +147,8 @@ export async function getUpcomingParticipations(userId: string): Promise<Upcomin
         eq(eventParticipations.status, "registered"),
         isNull(eventParticipations.deletedAt),
         isNull(events.deletedAt),
-        gt(events.endAt, now)
+        gt(events.endAt, now),
+        eq(events.status, "published")
       )
     )
     .orderBy(asc(events.startAt));
@@ -165,6 +167,8 @@ export async function getUpcomingParticipations(userId: string): Promise<Upcomin
  * - registered かつ endAt が過去、または cancelled
  * - 論理削除されていない参加レコードのみ
  * - 新しい順（events.startAt DESC）で返す
+ * - events.status はフィルタしない。キャンセル済みイベントも履歴として表示する設計のため
+ *   （docs/features/event-participation.md: 参加表明済み・参加済み・キャンセル済みを一覧表示）
  */
 export async function getParticipationHistory(userId: string): Promise<ParticipationHistoryItem[]> {
   const now = new Date();


### PR DESCRIPTION
## Summary

- `getUpcomingParticipations` に `eq(events.status, "published")` を追加し、cancelled/rejected 状態のイベントが参加予定に表示されないよう修正
- `getParticipationHistory` は events.status をフィルタしない設計である旨をコメントで明示（キャンセル済みイベントも履歴に表示する仕様: `docs/features/event-participation.md` 参照）
- `privacy/page.tsx` に `generateMetadata` を追加し、SEO 用の title/description を設定（既存翻訳キー `privacy.title` / `privacy.introduction` を再利用）

## Test plan

- [ ] `/ja/privacy` ページが正常表示されること
- [ ] `/en/privacy` ページが正常表示されること
- [ ] ブラウザの `<title>` タグに「プライバシーポリシー」が含まれること
- [ ] 参加予定ページで cancelled イベントが表示されないこと（DB にテストデータがあれば）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)