### PR TITLE
feat: SP ハンバーガーメニューを AppHeader に実装 (#37)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -116,6 +116,12 @@
     }
   },
   "dashboard": {
+    "nav": {
+      "dashboard": "Dashboard",
+      "account_settings": "Account Settings",
+      "admin": "Admin Panel",
+      "sign_out": "Sign Out"
+    },
     "title": "Dashboard",
     "calendar_title": "Event Calendar",
     "user_type_user": "User",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -116,6 +116,12 @@
     }
   },
   "dashboard": {
+    "nav": {
+      "dashboard": "ダッシュボード",
+      "account_settings": "アカウント設定",
+      "admin": "管理者画面",
+      "sign_out": "サインアウト"
+    },
     "title": "ダッシュボード",
     "calendar_title": "イベントカレンダー",
     "user_type_user": "一般ユーザー",

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -1,8 +1,8 @@
 import { getTranslations } from "next-intl/server";
-import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/server";
+import { signOutAction } from "@/lib/actions/auth";
+import { HamburgerMenu } from "@/components/layout/hamburger-menu";
 
 interface AppHeaderProps {
   userEmail: string;
@@ -12,13 +12,6 @@ interface AppHeaderProps {
 
 export async function AppHeader({ userEmail, userType, locale }: AppHeaderProps) {
   const t = await getTranslations("dashboard");
-
-  async function signOut() {
-    "use server";
-    const supabase = await createClient();
-    await supabase.auth.signOut();
-    redirect(`/${locale}/auth/sign-in`);
-  }
 
   return (
     <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur-sm">
@@ -33,16 +26,19 @@ export async function AppHeader({ userEmail, userType, locale }: AppHeaderProps)
           {userType === "system_user" && (
             <Link
               href={`/${locale}/admin`}
-              className="inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-2.5 text-[0.8rem] font-medium transition-colors hover:bg-muted"
+              className="hidden md:inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-2.5 text-[0.8rem] font-medium transition-colors hover:bg-muted"
             >
               {t("admin_link")}
             </Link>
           )}
-          <form action={signOut}>
-            <Button variant="outline" type="submit" size="sm" className="min-h-9">
+          {/* PC のみサインアウトボタン */}
+          <form action={signOutAction} className="hidden md:block">
+            <Button variant="outline" type="submit" size="sm" className="min-h-9 cursor-pointer">
               {t("sign_out")}
             </Button>
           </form>
+          {/* SP のみハンバーガーメニュー */}
+          <HamburgerMenu locale={locale} userType={userType} />
         </div>
       </div>
     </header>

--- a/apps/web/src/components/layout/hamburger-menu.tsx
+++ b/apps/web/src/components/layout/hamburger-menu.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Menu, LayoutDashboard, Settings, LogOut, Shield } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { signOutAction } from '@/lib/actions/auth';
+import { useTranslations } from 'next-intl';
+
+interface HamburgerMenuProps {
+  locale: string;
+  userType: 'user' | 'venue_user' | 'system_user';
+}
+
+export function HamburgerMenu({ locale, userType }: HamburgerMenuProps) {
+  const [open, setOpen] = useState(false);
+  const t = useTranslations('dashboard.nav');
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="md:hidden cursor-pointer"
+        onClick={() => setOpen(true)}
+        aria-label="メニューを開く"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="right" className="w-64">
+          <SheetHeader>
+            <SheetTitle>E-be</SheetTitle>
+          </SheetHeader>
+          <nav className="mt-6 flex flex-col gap-1">
+            <Link
+              href={`/${locale}/dashboard`}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-3 rounded-lg px-3 py-3 min-h-11 text-sm font-medium transition-colors hover:bg-muted cursor-pointer"
+            >
+              <LayoutDashboard className="h-4 w-4" />
+              {t('dashboard')}
+            </Link>
+            <Link
+              href={`/${locale}/dashboard/settings`}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-3 rounded-lg px-3 py-3 min-h-11 text-sm font-medium transition-colors hover:bg-muted cursor-pointer"
+            >
+              <Settings className="h-4 w-4" />
+              {t('account_settings')}
+            </Link>
+            {userType === 'system_user' && (
+              <Link
+                href={`/${locale}/admin`}
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-3 rounded-lg px-3 py-3 min-h-11 text-sm font-medium transition-colors hover:bg-muted cursor-pointer"
+              >
+                <Shield className="h-4 w-4" />
+                {t('admin')}
+              </Link>
+            )}
+            <div className="mt-2 border-t pt-2">
+              <form action={signOutAction}>
+                <button
+                  type="submit"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-3 min-h-11 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 cursor-pointer"
+                >
+                  <LogOut className="h-4 w-4" />
+                  {t('sign_out')}
+                </button>
+              </form>
+            </div>
+          </nav>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-3 right-3"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/apps/web/src/lib/actions/auth.ts
+++ b/apps/web/src/lib/actions/auth.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { getLocale } from 'next-intl/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function signOutAction() {
+  const [supabase, locale] = await Promise.all([createClient(), getLocale()]);
+  await supabase.auth.signOut();
+  redirect(`/${locale}/auth/sign-in`);
+}


### PR DESCRIPTION
## Summary

- SP（375px）でヘッダー右上にハンバーガーアイコンを表示
- タップで shadcn/ui Sheet が右からスライドイン
- メニュー項目: ダッシュボード / アカウント設定 / サインアウト（`system_user` は管理者画面も）
- PC（md 以上）はハンバーガー非表示、既存のサインアウトボタンを維持
- `signOutAction` を `lib/actions/auth.ts` に切り出し、AppHeader と HamburgerMenu で共有

## Test plan

- [x] SP（375px）でハンバーガーアイコンが表示される（Playwright で確認）
- [x] タップで Sheet が開き、3項目が表示される（Playwright で確認）
- [x] TypeScript エラー 0 件
- [ ] PC 表示でハンバーガーが非表示になること（手動確認推奨）

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)