### PR TITLE
perf: サインイン後の二重ナビゲーションを解消 (#44)

### DIFF
--- a/apps/web/src/app/[locale]/auth/sign-in/page.tsx
+++ b/apps/web/src/app/[locale]/auth/sign-in/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -32,7 +32,6 @@ const TEST_ACCOUNTS = [
 export default function SignInPage() {
   const t = useTranslations("auth");
   const locale = useLocale();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const next = searchParams.get("next") ?? `/${locale}/dashboard`;
 
@@ -57,8 +56,7 @@ export default function SignInPage() {
       return;
     }
 
-    router.push(next);
-    router.refresh();
+    window.location.href = next;
   }
 
   async function handleSubmit(e: React.FormEvent) {


### PR DESCRIPTION
## Summary

- `router.push(next)` + `router.refresh()` の連続呼び出しにより、ミドルウェアが2回実行され Supabase Auth への HTTP 呼び出しが3回発生していた
- `window.location.href = next` に変更し、1回のフルナビゲーションに削減
- 不要になった `useRouter` の import・変数宣言を削除

## Before / After

| | Before | After |
|---|---|---|
| Supabase API 呼び出し回数（サインイン時） | 3回 | 2回 |
| ミドルウェア実行回数（遷移時） | 2回 | 1回 |

## Test plan

- [ ] テストアカウント（一般ユーザー・事業者）でサインインし、ダッシュボードへ正常に遷移することを確認
- [ ] `next` パラメータ付きURL（例: `/ja/dashboard`）でも正しくリダイレクトされることを確認
- [ ] エラー時（パスワード誤り等）は従来通りエラーメッセージが表示されることを確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)