### PR TITLE
perf: パブリックパスでのミドルウェアセッション更新スキップ (#45)

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -18,11 +18,16 @@ export default async function proxy(request: NextRequest) {
   // 1. next-intl でロケールルーティング処理
   const intlResponse = intlMiddleware(request);
 
-  // 2. Supabase セッションを更新（cookie の refresh）
+  // 2. パブリックパスはセッション更新不要（Supabase への不要な HTTP 呼び出しを省略）
+  if (isPublicPath(request.nextUrl.pathname)) {
+    return intlResponse;
+  }
+
+  // 3. Supabase セッションを更新（cookie の refresh）
   const { response, user } = await updateSession(request, intlResponse);
 
-  // 3. 未認証 + 保護ルートならサインインへリダイレクト
-  if (!user && !isPublicPath(request.nextUrl.pathname)) {
+  // 4. 未認証なら保護ルートからサインインへリダイレクト
+  if (!user) {
     const locale = request.nextUrl.pathname.split("/")[1] || routing.defaultLocale;
     const signInUrl = new URL(`/${locale}/auth/sign-in`, request.url);
     signInUrl.searchParams.set("next", request.nextUrl.pathname);


### PR DESCRIPTION
## Summary

- `/auth/sign-in` 等のパブリックパスでも `updateSession()` が実行され、Supabase Auth への不要な HTTP 呼び出しが毎リクエスト発生していた
- `isPublicPath()` チェックを `updateSession()` の**前**に移動し、パブリックパスでは `intlResponse` をそのまま返すよう変更
- 保護ルートの認証チェックロジックは変更なし

## Before / After

| パス | Before | After |
|------|--------|-------|
| `/auth/sign-in` | `updateSession()` 実行（Supabase API 呼び出し） | スキップ |
| `/auth/sign-up` | `updateSession()` 実行（Supabase API 呼び出し） | スキップ |
| `/dashboard` 等 | `updateSession()` 実行 | 変更なし（認証必要） |

## Test plan

- [ ] サインインページ（`/ja/auth/sign-in`）が正常に表示される
- [ ] 未認証でダッシュボードにアクセスするとサインインへリダイレクトされる
- [ ] サインイン後にダッシュボードへ正常に遷移できる

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)