### PR TITLE
feat: イベント作成フォーム — バー選択・基本情報入力・下書き保存 (#40)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -137,6 +137,7 @@
     "role_member": "Member",
     "go_to_org": "Go to Organization",
     "admin_link": "Admin Dashboard",
+    "create_event": "Create Event",
     "organizer_history_title": "Organized Events",
     "organizer_history_empty": "You haven't organized any events yet",
     "event_status_published_ended": "Completed",
@@ -227,6 +228,24 @@
   "metadata": {
     "title": "E-be",
     "description": "The event bar management platform connecting venues and organizers"
+  },
+  "event_create": {
+    "title": "Create Event",
+    "back": "Back to Dashboard",
+    "field_bar": "Venue",
+    "field_bar_placeholder": "Select a venue",
+    "field_title": "Title",
+    "field_title_placeholder": "e.g. Shibuya Jazz Night Vol.1",
+    "field_description": "Description",
+    "field_description_placeholder": "Describe the event atmosphere and content",
+    "field_max_participants": "Capacity",
+    "field_max_participants_placeholder": "Leave blank for unlimited",
+    "submit": "Save Draft",
+    "submitting": "Saving...",
+    "error_unauthorized": "Please sign in",
+    "error_forbidden": "You don't have permission to create events",
+    "error_invalid": "Please check your inputs",
+    "error_unknown": "An error occurred. Please try again"
   },
   "event_detail": {
     "back": "Back to Dashboard",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -137,6 +137,7 @@
     "role_member": "メンバー",
     "go_to_org": "組織ダッシュボードへ",
     "admin_link": "管理者画面へ",
+    "create_event": "イベントを作成",
     "organizer_history_title": "主催イベント履歴",
     "organizer_history_empty": "主催したイベントはまだありません",
     "event_status_published_ended": "完了",
@@ -227,6 +228,24 @@
   "metadata": {
     "title": "イーベ (E-be)",
     "description": "良いイベントを増やす、店舗と主催者をつなぐイベントバー運営プラットフォーム"
+  },
+  "event_create": {
+    "title": "イベントを作成",
+    "back": "ダッシュボードへ戻る",
+    "field_bar": "開催バー",
+    "field_bar_placeholder": "バーを選択してください",
+    "field_title": "タイトル",
+    "field_title_placeholder": "例: 渋谷ジャズナイト Vol.1",
+    "field_description": "説明",
+    "field_description_placeholder": "イベントの内容・雰囲気などを書いてください",
+    "field_max_participants": "定員",
+    "field_max_participants_placeholder": "未設定の場合は定員なし",
+    "submit": "下書き保存",
+    "submitting": "保存中...",
+    "error_unauthorized": "ログインが必要です",
+    "error_forbidden": "イベント作成権限がありません",
+    "error_invalid": "入力内容を確認してください",
+    "error_unknown": "エラーが発生しました。もう一度お試しください"
   },
   "event_detail": {
     "back": "ダッシュボードへ戻る",

--- a/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select } from "@/components/ui/select";
+import { createEventDraft } from "@/lib/actions/event";
+import Link from "next/link";
+
+type Bar = { id: string; name: string };
+
+type Props = {
+  bars: Bar[];
+  locale: string;
+};
+
+export function EventCreateForm({ bars, locale }: Props) {
+  const t = useTranslations("event_create");
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await createEventDraft(formData);
+      if ("error" in result) {
+        const key = `error_${result.error}` as
+          | "error_unauthorized"
+          | "error_forbidden"
+          | "error_invalid"
+          | "error_unknown";
+        setError(t(key));
+        return;
+      }
+      router.push(`/${locale}/dashboard/event/${result.eventId}`);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="orgId">{t("field_bar")}</Label>
+            <Select id="orgId" name="orgId" required disabled={isPending}>
+              <option value="">{t("field_bar_placeholder")}</option>
+              {bars.map((bar) => (
+                <option key={bar.id} value={bar.id}>
+                  {bar.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="title">{t("field_title")}</Label>
+            <Input
+              id="title"
+              name="title"
+              placeholder={t("field_title_placeholder")}
+              maxLength={100}
+              required
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="description">{t("field_description")}</Label>
+            <Textarea
+              id="description"
+              name="description"
+              placeholder={t("field_description_placeholder")}
+              maxLength={2000}
+              rows={5}
+              required
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="maxParticipants">{t("field_max_participants")}</Label>
+            <Input
+              id="maxParticipants"
+              name="maxParticipants"
+              type="number"
+              placeholder={t("field_max_participants_placeholder")}
+              min={1}
+              max={500}
+              disabled={isPending}
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button type="submit" disabled={isPending}>
+              {isPending ? t("submitting") : t("submit")}
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/${locale}/dashboard`}>{t("back")}</Link>
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/event/create/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/create/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+import { getDbUser, getUserType } from "@/lib/auth";
+import { getPublicBars } from "@/lib/events";
+import { EventCreateForm } from "./event-create-form";
+
+export default async function EventCreatePage() {
+  const dbUser = await getDbUser();
+  if (!dbUser) notFound();
+
+  const userType = await getUserType(dbUser.id);
+  if (userType !== "user") notFound();
+
+  const [locale, t, bars] = await Promise.all([
+    getLocale(),
+    getTranslations("event_create"),
+    getPublicBars(),
+  ]);
+
+  return (
+    <main className="p-4 md:p-6">
+      <div className="mx-auto max-w-lg space-y-4">
+        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <EventCreateForm bars={bars} locale={locale} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -88,6 +88,17 @@ export default async function DashboardPage() {
         </Card>
 
         {userType === "user" && (
+          <div className="flex justify-end">
+            <Link
+              href={`/${locale}/dashboard/event/create`}
+              className="inline-flex min-h-11 items-center rounded-lg bg-primary px-4 text-[0.8rem] font-medium text-primary-foreground transition-all hover:bg-primary/90"
+            >
+              {t("create_event")}
+            </Link>
+          </div>
+        )}
+
+        {userType === "user" && (
           <Card>
             <CardHeader>
               <CardTitle>{t("upcoming_participations_title")}</CardTitle>

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Select({ className, ...props }: React.ComponentProps<"select">) {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Select }

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/apps/web/src/lib/actions/event.ts
+++ b/apps/web/src/lib/actions/event.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import { getDbUser, getUserType } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { events } from '@e-be/db/schema';
+
+type CreateEventDraftResult =
+  | { error: string }
+  | { eventId: string };
+
+export async function createEventDraft(formData: FormData): Promise<CreateEventDraftResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  const userType = await getUserType(dbUser.id);
+  if (userType !== 'user') return { error: 'forbidden' };
+
+  const orgId = formData.get('orgId') as string | null;
+  const title = (formData.get('title') as string | null)?.trim() ?? '';
+  const description = (formData.get('description') as string | null)?.trim() ?? '';
+  const maxParticipantsRaw = formData.get('maxParticipants') as string | null;
+
+  // バリデーション
+  if (!orgId || !/^[0-9a-f-]{36}$/.test(orgId)) return { error: 'invalid' };
+  if (!title || title.length > 100) return { error: 'invalid' };
+  if (!description || description.length > 2000) return { error: 'invalid' };
+
+  let maxParticipants: number | null = null;
+  if (maxParticipantsRaw && maxParticipantsRaw !== '') {
+    const n = parseInt(maxParticipantsRaw, 10);
+    if (isNaN(n) || n < 1 || n > 500) return { error: 'invalid' };
+    maxParticipants = n;
+  }
+
+  const [event] = await db
+    .insert(events)
+    .values({
+      orgId,
+      userId: dbUser.id,
+      status: 'draft',
+      title,
+      description,
+      maxParticipants,
+    })
+    .returning({ id: events.id });
+
+  return { eventId: event.id };
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -2,6 +2,18 @@ import { db } from "@/lib/db";
 import { events, eventParticipations, organizations } from "@e-be/db/schema";
 import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc } from "drizzle-orm";
 
+/**
+ * イベント作成フォームのバー選択用に公開バー一覧を取得する。
+ * deletedAt IS NULL の全組織を返す。
+ */
+export async function getPublicBars(): Promise<{ id: string; name: string }[]> {
+  return db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(isNull(organizations.deletedAt))
+    .orderBy(asc(organizations.name));
+}
+
 export type CalendarEventData = {
   id: string;
   title: string | null;


### PR DESCRIPTION
## Summary

- `/dashboard/event/create` にイベント作成フォームを実装
- `createEventDraft` Server Action でバリデーション・認証チェック・draft 保存
- ダッシュボードに「イベントを作成」ボタン追加（`userType=user` のみ表示）
- `Textarea` / `Select` UI コンポーネントを追加（既存の `Input` と同スタイル）
- 保存後は `/dashboard/event/{eventId}` へリダイレクト

## 変更ファイル

| ファイル | 変更種別 |
|---------|---------|
| `src/lib/events.ts` | `getPublicBars()` 追加 |
| `src/lib/actions/event.ts` | 新規: `createEventDraft` |
| `src/app/.../event/create/page.tsx` | 新規: Server Component ページ |
| `src/app/.../event/create/event-create-form.tsx` | 新規: Client Component フォーム |
| `src/app/.../dashboard/page.tsx` | ボタン追加 |
| `src/components/ui/textarea.tsx` | 新規 |
| `src/components/ui/select.tsx` | 新規 |
| `messages/ja.json` / `en.json` | `event_create` セクション追加 |

## Test plan

- [ ] 一般ユーザーでダッシュボードに「イベントを作成」ボタンが表示される
- [ ] 事業者ユーザーでは表示されない
- [ ] フォームでバー・タイトル・説明を入力して「下書き保存」→ イベント詳細ページへ遷移
- [ ] バー未選択 / タイトル空欄 / 説明空欄でバリデーションエラー
- [ ] 事業者ユーザーで `/dashboard/event/create` に直接アクセスすると 404

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)