### PR TITLE
feat: イベント下書き編集 — 日時設定・申請/公開アクション (#41)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -229,6 +229,28 @@
     "title": "E-be",
     "description": "The event bar management platform connecting venues and organizers"
   },
+  "event_edit": {
+    "title": "Edit Event",
+    "back": "Back to Dashboard",
+    "field_title": "Title",
+    "field_description": "Description",
+    "field_start_at": "Start Date & Time",
+    "field_end_at": "End Date & Time",
+    "field_max_participants": "Capacity",
+    "save_draft": "Save Draft",
+    "submit": "Submit for Approval",
+    "publish": "Publish",
+    "submitting": "Processing...",
+    "error_conflict": "This time slot conflicts with another event",
+    "error_past_date": "Cannot set a past date",
+    "error_invalid_range": "End time must be after start time",
+    "error_datetime_required": "Start and end times are required to submit or publish",
+    "error_permission_required": "You don't have permission to publish at this venue",
+    "error_invalid": "Please check your inputs",
+    "error_not_found": "Event not found",
+    "error_forbidden": "This action is not allowed",
+    "error_unauthorized": "Please sign in"
+  },
   "event_create": {
     "title": "Create Event",
     "back": "Back to Dashboard",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -229,6 +229,28 @@
     "title": "イーベ (E-be)",
     "description": "良いイベントを増やす、店舗と主催者をつなぐイベントバー運営プラットフォーム"
   },
+  "event_edit": {
+    "title": "イベントを編集",
+    "back": "ダッシュボードへ戻る",
+    "field_title": "タイトル",
+    "field_description": "説明",
+    "field_start_at": "開催開始日時",
+    "field_end_at": "開催終了日時",
+    "field_max_participants": "定員",
+    "save_draft": "下書き保存",
+    "submit": "申請する",
+    "publish": "公開する",
+    "submitting": "処理中...",
+    "error_conflict": "この時間帯は他のイベントと重複しています",
+    "error_past_date": "過去の日時は設定できません",
+    "error_invalid_range": "終了日時は開始日時より後に設定してください",
+    "error_datetime_required": "申請・公開には開始・終了日時が必須です",
+    "error_permission_required": "このバーへの公開許可がありません",
+    "error_invalid": "入力内容を確認してください",
+    "error_not_found": "イベントが見つかりません",
+    "error_forbidden": "この操作は許可されていません",
+    "error_unauthorized": "ログインが必要です"
+  },
   "event_create": {
     "title": "イベントを作成",
     "back": "ダッシュボードへ戻る",

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { updateEventDraft, submitEvent, publishEvent } from "@/lib/actions/event";
+import Link from "next/link";
+
+type EventData = {
+  id: string;
+  title: string | null;
+  description: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  maxParticipants: number | null;
+};
+
+type Props = {
+  event: EventData;
+  eventId: string;
+  hasPermission: boolean;
+  locale: string;
+};
+
+// ISO文字列を datetime-local input 用のフォーマットに変換
+function toDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  return iso.slice(0, 16); // "YYYY-MM-DDTHH:mm"
+}
+
+export function EventEditForm({ event, eventId, hasPermission, locale }: Props) {
+  const t = useTranslations("event_edit");
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [startAt, setStartAt] = useState(toDatetimeLocal(event.startAt));
+  const [endAt, setEndAt] = useState(toDatetimeLocal(event.endAt));
+
+  const hasDatetime = startAt !== "" && endAt !== "";
+
+  function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await updateEventDraft(eventId, formData);
+      if ("error" in result) {
+        setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  function handleSubmit() {
+    setError(null);
+    startTransition(async () => {
+      const result = await submitEvent(eventId);
+      if ("error" in result) {
+        setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        return;
+      }
+      router.push(`/${locale}/dashboard`);
+    });
+  }
+
+  function handlePublish() {
+    setError(null);
+    startTransition(async () => {
+      const result = await publishEvent(eventId);
+      if ("error" in result) {
+        setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        return;
+      }
+      router.push(`/${locale}/dashboard/event/${eventId}`);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="title">{t("field_title")}</Label>
+            <Input
+              id="title"
+              name="title"
+              defaultValue={event.title ?? ""}
+              maxLength={100}
+              required
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="description">{t("field_description")}</Label>
+            <Textarea
+              id="description"
+              name="description"
+              defaultValue={event.description ?? ""}
+              maxLength={2000}
+              rows={5}
+              required
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="startAt">{t("field_start_at")}</Label>
+            <Input
+              id="startAt"
+              name="startAt"
+              type="datetime-local"
+              value={startAt}
+              onChange={(e) => setStartAt(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="endAt">{t("field_end_at")}</Label>
+            <Input
+              id="endAt"
+              name="endAt"
+              type="datetime-local"
+              value={endAt}
+              onChange={(e) => setEndAt(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="maxParticipants">{t("field_max_participants")}</Label>
+            <Input
+              id="maxParticipants"
+              name="maxParticipants"
+              type="number"
+              defaultValue={event.maxParticipants ?? ""}
+              min={1}
+              max={500}
+              disabled={isPending}
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button type="submit" variant="outline" disabled={isPending}>
+              {isPending ? t("submitting") : t("save_draft")}
+            </Button>
+
+            {hasPermission ? (
+              <Button
+                type="button"
+                disabled={isPending || !hasDatetime}
+                onClick={handlePublish}
+              >
+                {isPending ? t("submitting") : t("publish")}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                disabled={isPending || !hasDatetime}
+                onClick={handleSubmit}
+              >
+                {isPending ? t("submitting") : t("submit")}
+              </Button>
+            )}
+
+            <Button variant="outline" asChild>
+              <Link href={`/${locale}/dashboard`}>{t("back")}</Link>
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+import { getDbUser } from "@/lib/auth";
+import { getDraftEventForOwner, hasBarHostPermission } from "@/lib/events";
+import { EventEditForm } from "./event-edit-form";
+
+type Props = {
+  params: Promise<{ eventId: string }>;
+};
+
+export default async function EventEditPage({ params }: Props) {
+  const { eventId } = await params;
+
+  const dbUser = await getDbUser();
+  if (!dbUser) notFound();
+
+  const event = await getDraftEventForOwner(eventId, dbUser.id);
+  if (!event) notFound();
+  // draft のみ編集可能。pending 以降は 404
+  if (event.status !== "draft") notFound();
+
+  const [locale, t, hasPermission] = await Promise.all([
+    getLocale(),
+    getTranslations("event_edit"),
+    hasBarHostPermission(dbUser.id, event.orgId),
+  ]);
+
+  return (
+    <main className="p-4 md:p-6">
+      <div className="mx-auto max-w-lg space-y-4">
+        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <EventEditForm event={event} hasPermission={hasPermission} locale={locale} eventId={eventId} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -1,7 +1,7 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
-import { getUser } from "@/lib/auth";
-import { getEventDetail } from "@/lib/events";
+import { getUser, getDbUser } from "@/lib/auth";
+import { getEventDetail, getDraftEventForOwner } from "@/lib/events";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
@@ -19,7 +19,15 @@ export default async function EventDetailPage({ params }: Props) {
   if (!user) notFound();
 
   const event = await getEventDetail(eventId, user.id);
-  if (!event) notFound();
+  if (!event) {
+    // draft/pending イベントなら編集ページへリダイレクト
+    const dbUser = await getDbUser();
+    if (dbUser) {
+      const draft = await getDraftEventForOwner(eventId, dbUser.id);
+      if (draft) redirect(`/${locale}/dashboard/event/${eventId}/edit`);
+    }
+    notFound();
+  }
 
   const formatDate = (iso: string | null) =>
     iso

--- a/apps/web/src/lib/actions/event.ts
+++ b/apps/web/src/lib/actions/event.ts
@@ -3,6 +3,8 @@
 import { getDbUser, getUserType } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { events } from '@e-be/db/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import { checkEventConflict, hasBarHostPermission } from '@/lib/events';
 
 type CreateEventDraftResult =
   | { error: string }
@@ -45,4 +47,103 @@ export async function createEventDraft(formData: FormData): Promise<CreateEventD
     .returning({ id: events.id });
 
   return { eventId: event.id };
+}
+
+type ActionResult = { error: string } | { ok: true };
+
+/** draft イベントの基本情報と日時を更新する */
+export async function updateEventDraft(eventId: string, formData: FormData): Promise<ActionResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  const title = (formData.get('title') as string | null)?.trim() ?? '';
+  const description = (formData.get('description') as string | null)?.trim() ?? '';
+  const startAtRaw = formData.get('startAt') as string | null;
+  const endAtRaw = formData.get('endAt') as string | null;
+  const maxParticipantsRaw = formData.get('maxParticipants') as string | null;
+
+  if (!title || title.length > 100) return { error: 'invalid' };
+  if (!description || description.length > 2000) return { error: 'invalid' };
+
+  let maxParticipants: number | null = null;
+  if (maxParticipantsRaw && maxParticipantsRaw !== '') {
+    const n = parseInt(maxParticipantsRaw, 10);
+    if (isNaN(n) || n < 1 || n > 500) return { error: 'invalid' };
+    maxParticipants = n;
+  }
+
+  // 所有権チェック
+  const [target] = await db
+    .select({ id: events.id, status: events.status })
+    .from(events)
+    .where(and(eq(events.id, eventId), eq(events.userId, dbUser.id), isNull(events.deletedAt)))
+    .limit(1);
+
+  if (!target) return { error: 'not_found' };
+  if (target.status !== 'draft') return { error: 'forbidden' };
+
+  const startAt = startAtRaw ? new Date(startAtRaw) : null;
+  const endAt = endAtRaw ? new Date(endAtRaw) : null;
+
+  await db
+    .update(events)
+    .set({ title, description, startAt, endAt, maxParticipants, updatedAt: new Date() })
+    .where(eq(events.id, eventId));
+
+  return { ok: true };
+}
+
+/** draft → pending（バーへの開催申請） */
+export async function submitEvent(eventId: string): Promise<ActionResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  const [target] = await db
+    .select({ id: events.id, status: events.status, orgId: events.orgId, startAt: events.startAt, endAt: events.endAt })
+    .from(events)
+    .where(and(eq(events.id, eventId), eq(events.userId, dbUser.id), isNull(events.deletedAt)))
+    .limit(1);
+
+  if (!target) return { error: 'not_found' };
+  if (target.status !== 'draft') return { error: 'forbidden' };
+  if (!target.startAt || !target.endAt) return { error: 'datetime_required' };
+
+  const now = new Date();
+  if (target.startAt <= now) return { error: 'past_date' };
+  if (target.endAt <= target.startAt) return { error: 'invalid_range' };
+
+  const conflict = await checkEventConflict(target.orgId, target.startAt, target.endAt, eventId);
+  if (conflict) return { error: 'conflict' };
+
+  await db.update(events).set({ status: 'pending', updatedAt: new Date() }).where(eq(events.id, eventId));
+  return { ok: true };
+}
+
+/** draft → published（許可済みユーザーが即時公開） */
+export async function publishEvent(eventId: string): Promise<ActionResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  const [target] = await db
+    .select({ id: events.id, status: events.status, orgId: events.orgId, startAt: events.startAt, endAt: events.endAt })
+    .from(events)
+    .where(and(eq(events.id, eventId), eq(events.userId, dbUser.id), isNull(events.deletedAt)))
+    .limit(1);
+
+  if (!target) return { error: 'not_found' };
+  if (target.status !== 'draft') return { error: 'forbidden' };
+  if (!target.startAt || !target.endAt) return { error: 'datetime_required' };
+
+  const now = new Date();
+  if (target.startAt <= now) return { error: 'past_date' };
+  if (target.endAt <= target.startAt) return { error: 'invalid_range' };
+
+  const permitted = await hasBarHostPermission(dbUser.id, target.orgId);
+  if (!permitted) return { error: 'permission_required' };
+
+  const conflict = await checkEventConflict(target.orgId, target.startAt, target.endAt, eventId);
+  if (conflict) return { error: 'conflict' };
+
+  await db.update(events).set({ status: 'published', updatedAt: new Date() }).where(eq(events.id, eventId));
+  return { ok: true };
 }

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
-import { events, eventParticipations, organizations } from "@e-be/db/schema";
-import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc } from "drizzle-orm";
+import { events, eventParticipations, organizations, barHostPermissions, barBlocks } from "@e-be/db/schema";
+import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray } from "drizzle-orm";
 
 /**
  * イベント作成フォームのバー選択用に公開バー一覧を取得する。
@@ -12,6 +12,113 @@ export async function getPublicBars(): Promise<{ id: string; name: string }[]> {
     .from(organizations)
     .where(isNull(organizations.deletedAt))
     .orderBy(asc(organizations.name));
+}
+
+/** ユーザーが指定バーへの公開許可を持つか確認する */
+export async function hasBarHostPermission(userId: string, barId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: barHostPermissions.id })
+    .from(barHostPermissions)
+    .where(
+      and(
+        eq(barHostPermissions.userId, userId),
+        eq(barHostPermissions.barId, barId),
+        isNull(barHostPermissions.revokedAt),
+        isNull(barHostPermissions.deletedAt)
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * 指定バー・時間帯に既存のイベント/ブロックが重複するか確認する。
+ * published / pending イベントおよび bar_blocks を対象とする。
+ * excludeEventId を指定した場合は自己競合を除外する。
+ */
+export async function checkEventConflict(
+  barId: string,
+  startAt: Date,
+  endAt: Date,
+  excludeEventId?: string
+): Promise<boolean> {
+  // イベント重複チェック（時間帯が重なる = startAt < endAt2 AND endAt > startAt2）
+  const eventConditions = and(
+    eq(events.orgId, barId),
+    inArray(events.status, ["published", "pending"]),
+    isNull(events.deletedAt),
+    lt(events.startAt, endAt),
+    gt(events.endAt, startAt),
+    ...(excludeEventId ? [ne(events.id, excludeEventId)] : [])
+  );
+
+  const conflictingEvents = await db
+    .select({ id: events.id })
+    .from(events)
+    .where(eventConditions)
+    .limit(1);
+
+  if (conflictingEvents.length > 0) return true;
+
+  // barBlocks 重複チェック
+  const blockConflicts = await db
+    .select({ id: barBlocks.id })
+    .from(barBlocks)
+    .where(
+      and(
+        eq(barBlocks.barId, barId),
+        isNull(barBlocks.deletedAt),
+        lt(barBlocks.startAt, endAt),
+        gt(barBlocks.endAt, startAt)
+      )
+    )
+    .limit(1);
+
+  return blockConflicts.length > 0;
+}
+
+/** オーナー用 draft/pending イベントを取得する（編集ページ用） */
+export async function getDraftEventForOwner(
+  eventId: string,
+  userId: string
+): Promise<{
+  id: string;
+  orgId: string;
+  status: string;
+  title: string | null;
+  description: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  maxParticipants: number | null;
+} | null> {
+  const rows = await db
+    .select({
+      id: events.id,
+      orgId: events.orgId,
+      status: events.status,
+      title: events.title,
+      description: events.description,
+      startAt: events.startAt,
+      endAt: events.endAt,
+      maxParticipants: events.maxParticipants,
+    })
+    .from(events)
+    .where(
+      and(
+        eq(events.id, eventId),
+        eq(events.userId, userId),
+        isNull(events.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  return {
+    ...row,
+    startAt: row.startAt?.toISOString() ?? null,
+    endAt: row.endAt?.toISOString() ?? null,
+  };
 }
 
 export type CalendarEventData = {


### PR DESCRIPTION
## Summary

- `/dashboard/event/[eventId]/edit` に下書き編集ページを実装
- タイトル・説明・日時・定員の編集 + 下書き保存
- `barHostPermissions` の有無で「申請する」/「公開する」ボタンを切り替え
- 申請・公開前に重複チェック（同バー・同時間帯の published/pending イベント + barBlocks）
- イベント詳細ページ（`/dashboard/event/[eventId]`）でドラフトへアクセスした場合は編集ページへリダイレクト

## 変更ファイル

| ファイル | 変更種別 |
|---------|---------|
| `src/lib/events.ts` | `hasBarHostPermission`, `checkEventConflict`, `getDraftEventForOwner` 追加 |
| `src/lib/actions/event.ts` | `updateEventDraft`, `submitEvent`, `publishEvent` 追加 |
| `src/app/.../[eventId]/edit/page.tsx` | 新規 |
| `src/app/.../[eventId]/edit/event-edit-form.tsx` | 新規 |
| `src/app/.../[eventId]/page.tsx` | draft → edit ページへリダイレクト追加 |
| `messages/ja.json` / `en.json` | `event_edit` セクション追加 |

## Test plan

- [ ] draft イベントが編集ページで開ける
- [ ] pending イベントの編集ページは 404
- [ ] 日時未設定で「申請する」「公開する」ボタンが非活性
- [ ] 申請後 status が `pending` になる（DB 確認）
- [ ] 重複イベントがある場合はエラーが表示される

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)