### PR TITLE
feat: フロストガラスエフェクトの実装（Card・ヘッダー）(#49)

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/layout.tsx
+++ b/apps/web/src/app/[locale]/dashboard/layout.tsx
@@ -18,7 +18,12 @@ export default async function DashboardLayout({
   const userType = await getUserType(user.id);
 
   return (
-    <div className="flex min-h-screen flex-col bg-background">
+    <div className="relative flex min-h-screen flex-col bg-background">
+      {/* 装飾グラデーション — glass エフェクトの背景として機能する */}
+      <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-[oklch(0.8_0.08_260/0.35)] blur-3xl dark:bg-[oklch(0.4_0.08_260/0.25)]" />
+        <div className="absolute -bottom-32 -right-16 h-80 w-80 rounded-full bg-[oklch(0.85_0.06_300/0.30)] blur-3xl dark:bg-[oklch(0.35_0.06_300/0.20)]" />
+      </div>
       <AppHeader
         userEmail={user.email ?? ""}
         userType={userType}

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -73,7 +73,7 @@ export default async function DashboardPage() {
           </Badge>
         </div>
 
-        <Card>
+        <Card variant="glass">
           <CardHeader>
             <CardTitle>{t("calendar_title")}</CardTitle>
           </CardHeader>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -116,6 +116,19 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+@layer utilities {
+  .glass {
+    background: oklch(1 0 0 / 0.65);
+    backdrop-filter: blur(12px) saturate(1.5);
+    -webkit-backdrop-filter: blur(12px) saturate(1.5);
+    border: 1px solid oklch(1 0 0 / 0.3);
+  }
+  .dark .glass {
+    background: oklch(0.2 0 0 / 0.65);
+    border: 1px solid oklch(1 0 0 / 0.1);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -14,7 +14,7 @@ export async function AppHeader({ userEmail, userType, locale }: AppHeaderProps)
   const t = await getTranslations("dashboard");
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur-sm">
+    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur-md">
       <div className="mx-auto flex max-w-2xl items-center justify-between px-4 h-14 md:px-6">
         <Link href={`/${locale}`} className="text-base font-bold tracking-tight">
           E-be

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -5,14 +5,21 @@ import { cn } from "@/lib/utils"
 function Card({
   className,
   size = "default",
+  variant = "default",
   ...props
-}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+}: React.ComponentProps<"div"> & {
+  size?: "default" | "sm";
+  variant?: "default" | "glass";
+}) {
   return (
     <div
       data-slot="card"
       data-size={size}
+      data-variant={variant}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl py-4 text-sm text-card-foreground has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        variant === "default" && "bg-card ring-1 ring-foreground/10",
+        variant === "glass" && "glass",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- `globals.css` に `.glass` ユーティリティを追加（`backdrop-filter: blur(12px) saturate(1.5)`、ライト/ダーク両対応）
- `dashboard/layout.tsx` に装飾グラデーション背景を追加（`fixed -z-10`、ブラーの背景として機能）
- `Card` に `variant="glass"` を opt-in 追加（既存の `variant="default"` は変更なし）
- `AppHeader` の blur を `blur-sm → blur-md`、背景透過度を `95% → 80%` に調整
- ダッシュボードのカレンダーカードに `variant="glass"` を適用

## 将来の屈折エフェクト拡張パス

`globals.css` に以下を追加するだけで対応可能（リライト不要）:
```css
.glass-refraction {
  filter: url(#glass-distortion);
}
```

## Test plan

- [ ] ダッシュボード表示時に背景グラデーションが確認できる
- [ ] カレンダーカードがガラス調の半透明になっている
- [ ] ヘッダーのブラーエフェクトが強化されている
- [ ] 既存カード（`variant` 未指定）の見た目が変わっていない
- [ ] ダークモードで視認性が保たれている

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)