### PR TITLE
feat: LP ボタン導線を修正（href="#" → 正しいパス） #53

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -71,10 +71,15 @@ export default async function HomePage() {
             {t("hero.subtitle")}
           </p>
           <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <LinkButton href="#" size="lg" className="w-full sm:w-auto">
+            <LinkButton href={`/${locale}/dashboard`} size="lg" className="w-full sm:w-auto">
               {t("hero.cta_primary")}
             </LinkButton>
-            <LinkButton href="#" size="lg" variant="outline" className="w-full sm:w-auto">
+            <LinkButton
+              href={user ? `/${locale}/dashboard/event/create` : `/${locale}/auth/sign-up`}
+              size="lg"
+              variant="outline"
+              className="w-full sm:w-auto"
+            >
               {t("hero.cta_secondary")}
             </LinkButton>
           </div>
@@ -297,7 +302,11 @@ export default async function HomePage() {
             <p className="mb-8 text-muted-foreground">
               {t("cta_section.subtitle")}
             </p>
-            <LinkButton href="#" size="lg" className="min-w-40">
+            <LinkButton
+              href={user ? `/${locale}/dashboard` : `/${locale}/auth/sign-up`}
+              size="lg"
+              className="min-w-40"
+            >
               {t("cta_section.button")}
             </LinkButton>
           </div>


### PR DESCRIPTION
## 概要

トップページ（LP）のヒーローセクション・CTAセクションのボタンが `href="#"` のまま未実装だったため、正しい遷移先に修正した。

## 変更内容

| ボタン | 未ログイン | ログイン済み |
|--------|-----------|------------|
| 「イベントを探す」（Hero） | `/dashboard` | `/dashboard` |
| 「開催を申し込む」（Hero） | `/auth/sign-up` | `/dashboard/event/create` |
| 「無料で始める」（CTA） | `/auth/sign-up` | `/dashboard` |

## 実装方針

- `user` 変数（`getUser()` で取得済み）と `locale` を使い、NavBar と同じパターンで条件分岐
- 「イベントを探す」の最終的な遷移先（公開イベント一覧）は未実装のため `/dashboard` で暫定対応

## 検証

- Playwright MCP でスクリーンショット取得・リンク先を確認済み
- 未ログイン状態: 3つのボタンすべて正しいURLを確認

closes #53