### PR TITLE
perf: getLocale / getTranslations / getUser を Promise.all で並列化 (#56)

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -11,11 +11,12 @@ type Props = {
 };
 
 export default async function EventDetailPage({ params }: Props) {
-  const { eventId } = await params;
-  const locale = await getLocale();
-  const t = await getTranslations("event_detail");
-
-  const user = await getUser();
+  const [{ eventId }, locale, t, user] = await Promise.all([
+    params,
+    getLocale(),
+    getTranslations("event_detail"),
+    getUser(),
+  ]);
   if (!user) notFound();
 
   const event = await getEventDetail(eventId, user.id);

--- a/apps/web/src/app/[locale]/dashboard/org/[orgId]/settings/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/org/[orgId]/settings/page.tsx
@@ -9,11 +9,12 @@ type Props = {
 };
 
 export default async function OrgSettingsPage({ params }: Props) {
-  const { orgId } = await params;
-  const locale = await getLocale();
-  const t = await getTranslations("dashboard");
-
-  const user = await getUser();
+  const [{ orgId }, locale, t, user] = await Promise.all([
+    params,
+    getLocale(),
+    getTranslations("dashboard"),
+    getUser(),
+  ]);
   if (!user) {
     redirect(`/${locale}/auth/sign-in`);
   }


### PR DESCRIPTION
## Summary

- イベント詳細・組織設定ページで直列 await されていた独立した非同期処理を `Promise.all()` で並列実行
- `params`, `getLocale()`, `getTranslations()`, `getUser()` は相互に依存しないため並列化可能
- `getOrgRole(user.id, orgId)` は `user.id` に依存するため直列のまま維持

## 変更ファイル

- `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
- `apps/web/src/app/[locale]/dashboard/org/[orgId]/settings/page.tsx`

## 期待される効果

数十〜百 ms の TTFB 削減。Issue #54（getSession 化）と組み合わせることで体感速度が改善する。

## Test plan

- [x] イベント詳細ページ正常表示（Playwright 確認済み）
- [x] ダッシュボード正常表示
- [x] サインイン → リダイレクト正常動作
- [ ] 組織設定ページ正常表示（owner アカウントで確認）

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)