### PR TITLE
feat: イベント参加・キャンセル機能を実装 (#60)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -285,7 +285,13 @@
     "status_cancelled": "Cancelled",
     "venue": "Venue",
     "charge_amount": "Cover Charge",
-    "description": "About This Event"
+    "description": "About This Event",
+    "join_button": "Join",
+    "cancel_button": "Cancel Participation",
+    "full_capacity": "Full",
+    "event_ended": "Ended",
+    "joining": "Processing...",
+    "cancelling": "Processing..."
   },
   "privacy": {
     "title": "Privacy Policy",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -285,7 +285,13 @@
     "status_cancelled": "キャンセル済み",
     "venue": "開催店舗",
     "charge_amount": "チャージ料",
-    "description": "イベント詳細"
+    "description": "イベント詳細",
+    "join_button": "参加する",
+    "cancel_button": "参加をキャンセル",
+    "full_capacity": "定員満",
+    "event_ended": "終了済み",
+    "joining": "処理中...",
+    "cancelling": "処理中..."
   },
   "privacy": {
     "title": "プライバシーポリシー",

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -5,6 +5,7 @@ import { getEventDetail, getDraftEventForOwner } from "@/lib/events";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
+import { ParticipationButton } from "./participation-button";
 
 type Props = {
   params: Promise<{ eventId: string }>;
@@ -50,6 +51,8 @@ export default async function EventDetailPage({ params }: Props) {
 
   const isRegistered = event.myParticipationStatus === "registered";
   const isCancelled = event.myParticipationStatus === "cancelled";
+  const isBeforeEvent = !!(event.startAt && new Date(event.startAt) > new Date());
+  const isFull = event.maxParticipants !== null && event.participantCount >= event.maxParticipants;
 
   const startDate = formatDate(event.startAt);
   const startTime = formatTime(event.startAt);
@@ -175,15 +178,15 @@ export default async function EventDetailPage({ params }: Props) {
         </Card>
 
         {/* 参加ステータスカード */}
-        {event.myParticipationStatus && (
-          <Card
-            className={
-              isRegistered
-                ? "border-green-500/40 bg-green-500/5"
-                : "border-border"
-            }
-          >
-            <CardContent className="pt-4 pb-4">
+        <Card
+          className={
+            isRegistered
+              ? "border-green-500/40 bg-green-500/5"
+              : "border-border"
+          }
+        >
+          <CardContent className="pt-4 pb-4 space-y-3">
+            {event.myParticipationStatus && (
               <div className="flex items-center justify-between gap-3">
                 <div className="space-y-0.5">
                   <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
@@ -200,9 +203,21 @@ export default async function EventDetailPage({ params }: Props) {
                   {isRegistered ? "✓" : "✕"}
                 </span>
               </div>
-            </CardContent>
-          </Card>
-        )}
+            )}
+            <ParticipationButton
+              eventId={event.id}
+              myStatus={event.myParticipationStatus}
+              isFull={isFull}
+              isBeforeEvent={isBeforeEvent}
+              joinLabel={t("join_button")}
+              cancelLabel={t("cancel_button")}
+              fullLabel={t("full_capacity")}
+              endedLabel={t("event_ended")}
+              joiningLabel={t("joining")}
+              cancellingLabel={t("cancelling")}
+            />
+          </CardContent>
+        </Card>
 
       </div>
     </main>

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/participation-button.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/participation-button.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { joinEvent, cancelParticipation } from '@/lib/actions/participation';
+
+type Props = {
+  eventId: string;
+  myStatus: 'registered' | 'cancelled' | null;
+  isFull: boolean;
+  isBeforeEvent: boolean;
+  joinLabel: string;
+  cancelLabel: string;
+  fullLabel: string;
+  endedLabel: string;
+  cancellingLabel: string;
+  joiningLabel: string;
+};
+
+export function ParticipationButton({
+  eventId,
+  myStatus,
+  isFull,
+  isBeforeEvent,
+  joinLabel,
+  cancelLabel,
+  fullLabel,
+  endedLabel,
+  cancellingLabel,
+  joiningLabel,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const handleJoin = () => {
+    startTransition(async () => {
+      await joinEvent(eventId);
+      router.refresh();
+    });
+  };
+
+  const handleCancel = () => {
+    startTransition(async () => {
+      await cancelParticipation(eventId);
+      router.refresh();
+    });
+  };
+
+  if (!isBeforeEvent) {
+    return (
+      <Button disabled variant="outline" className="w-full">
+        {endedLabel}
+      </Button>
+    );
+  }
+
+  if (myStatus === 'registered') {
+    return (
+      <Button
+        onClick={handleCancel}
+        disabled={isPending}
+        variant="outline"
+        className="w-full border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700 active:bg-red-100"
+      >
+        {isPending ? cancellingLabel : cancelLabel}
+      </Button>
+    );
+  }
+
+  if (isFull) {
+    return (
+      <Button disabled variant="outline" className="w-full">
+        {fullLabel}
+      </Button>
+    );
+  }
+
+  return (
+    <Button onClick={handleJoin} disabled={isPending} className="w-full">
+      {isPending ? joiningLabel : joinLabel}
+    </Button>
+  );
+}

--- a/apps/web/src/lib/actions/participation.ts
+++ b/apps/web/src/lib/actions/participation.ts
@@ -1,0 +1,129 @@
+'use server';
+
+import { getDbUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { events, eventParticipations } from '@e-be/db/schema';
+import { eq, and, isNull, count } from 'drizzle-orm';
+import { sendNotification } from '@/lib/notify';
+import { NOTIFICATION_TYPES } from '@e-be/db';
+
+type ActionResult = { error: string } | { ok: true };
+
+export async function joinEvent(eventId: string): Promise<ActionResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  // イベント取得（published かつ deleted_at IS NULL）
+  const [event] = await db
+    .select({
+      id: events.id,
+      userId: events.userId,
+      startAt: events.startAt,
+      maxParticipants: events.maxParticipants,
+    })
+    .from(events)
+    .where(and(eq(events.id, eventId), eq(events.status, 'published'), isNull(events.deletedAt)))
+    .limit(1);
+
+  if (!event) return { error: 'not_found' };
+
+  // 開催前チェック
+  const now = new Date();
+  if (!event.startAt || event.startAt <= now) return { error: 'event_ended' };
+
+  // 既存参加レコードを確認
+  const [existing] = await db
+    .select({ id: eventParticipations.id, status: eventParticipations.status })
+    .from(eventParticipations)
+    .where(
+      and(
+        eq(eventParticipations.eventId, eventId),
+        eq(eventParticipations.userId, dbUser.id),
+        isNull(eventParticipations.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (existing?.status === 'registered') return { error: 'already_registered' };
+
+  // 定員チェック
+  if (event.maxParticipants !== null) {
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(eventParticipations)
+      .where(
+        and(
+          eq(eventParticipations.eventId, eventId),
+          eq(eventParticipations.status, 'registered'),
+          isNull(eventParticipations.deletedAt)
+        )
+      );
+    if (total >= event.maxParticipants) return { error: 'full_capacity' };
+  }
+
+  // INSERT または UPDATE
+  if (existing) {
+    // status が 'cancelled' だったケース → registered に戻す
+    await db
+      .update(eventParticipations)
+      .set({ status: 'registered', updatedAt: new Date() })
+      .where(eq(eventParticipations.id, existing.id));
+  } else {
+    await db.insert(eventParticipations).values({
+      eventId,
+      userId: dbUser.id,
+      status: 'registered',
+    });
+  }
+
+  // 主催者へ通知
+  await sendNotification(
+    event.userId,
+    NOTIFICATION_TYPES.PARTICIPATION_RECEIVED,
+    '参加表明がありました',
+    `イベントへの参加表明が届きました。`,
+    { eventId }
+  );
+
+  return { ok: true };
+}
+
+export async function cancelParticipation(eventId: string): Promise<ActionResult> {
+  const dbUser = await getDbUser();
+  if (!dbUser) return { error: 'unauthorized' };
+
+  // 参加レコードを取得
+  const [participation] = await db
+    .select({ id: eventParticipations.id })
+    .from(eventParticipations)
+    .where(
+      and(
+        eq(eventParticipations.eventId, eventId),
+        eq(eventParticipations.userId, dbUser.id),
+        eq(eventParticipations.status, 'registered'),
+        isNull(eventParticipations.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (!participation) return { error: 'not_found' };
+
+  // イベントの開催前チェック
+  const [event] = await db
+    .select({ startAt: events.startAt })
+    .from(events)
+    .where(and(eq(events.id, eventId), isNull(events.deletedAt)))
+    .limit(1);
+
+  if (!event) return { error: 'not_found' };
+
+  const now = new Date();
+  if (event.startAt && event.startAt <= now) return { error: 'event_started' };
+
+  await db
+    .update(eventParticipations)
+    .set({ status: 'cancelled', updatedAt: new Date() })
+    .where(eq(eventParticipations.id, participation.id));
+
+  return { ok: true };
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { events, eventParticipations, organizations, barHostPermissions, barBlocks } from "@e-be/db/schema";
-import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray } from "drizzle-orm";
+import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray, count } from "drizzle-orm";
 
 /**
  * イベント作成フォームのバー選択用に公開バー一覧を取得する。
@@ -377,7 +377,27 @@ export type EventDetail = {
   orgName: string;
   orgAddress: string | null;
   myParticipationStatus: "registered" | "cancelled" | null;
+  participantCount: number;
+  maxParticipants: number | null;
 };
+
+/**
+ * 指定イベントの現在の参加者数を返す。
+ * - status = 'registered' かつ deletedAt IS NULL の件数
+ */
+export async function getEventParticipantCount(eventId: string): Promise<number> {
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(eventParticipations)
+    .where(
+      and(
+        eq(eventParticipations.eventId, eventId),
+        eq(eventParticipations.status, "registered"),
+        isNull(eventParticipations.deletedAt)
+      )
+    );
+  return total;
+}
 
 /**
  * イベント詳細を取得する。
@@ -397,6 +417,7 @@ export async function getEventDetail(
       endAt: events.endAt,
       location: events.location,
       chargeAmount: events.chargeAmount,
+      maxParticipants: events.maxParticipants,
       orgName: organizations.name,
       orgAddress: organizations.address,
       participationStatus: eventParticipations.status,
@@ -423,6 +444,7 @@ export async function getEventDetail(
   if (rows.length === 0) return null;
 
   const row = rows[0];
+  const participantCount = await getEventParticipantCount(eventId);
   return {
     id: row.id,
     title: row.title,
@@ -431,8 +453,10 @@ export async function getEventDetail(
     endAt: row.endAt?.toISOString() ?? null,
     location: row.location,
     chargeAmount: row.chargeAmount ?? null,
+    maxParticipants: row.maxParticipants ?? null,
     orgName: row.orgName,
     orgAddress: row.orgAddress,
     myParticipationStatus: row.participationStatus ?? null,
+    participantCount,
   };
 }

--- a/apps/web/src/lib/notify.ts
+++ b/apps/web/src/lib/notify.ts
@@ -1,0 +1,13 @@
+'use server';
+import { db } from '@/lib/db';
+import { notifications } from '@e-be/db/schema';
+
+export async function sendNotification(
+  userId: string,
+  type: string,
+  title: string,
+  body: string,
+  payload?: Record<string, unknown>
+): Promise<void> {
+  await db.insert(notifications).values({ userId, type, title, body, payload: payload ?? null });
+}

--- a/packages/db/src/notification-types.ts
+++ b/packages/db/src/notification-types.ts
@@ -5,6 +5,7 @@ export const NOTIFICATION_TYPES = {
   EVENT_CANCELLED: 'event_cancelled', // 関係者向け：キャンセル
   NEW_COUPON: 'new_coupon', // ユーザー向け：新規クーポン配布
   OWNERSHIP_TRANSFERRED: 'ownership_transferred', // メンバー向け：権限移譲
+  PARTICIPATION_RECEIVED: 'participation_received', // 主催者向け：参加表明受領
 } as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[keyof typeof NOTIFICATION_TYPES];


### PR DESCRIPTION
## 概要

イベント詳細ページに参加表明・キャンセル機能を追加する。定員チェック・開催前チェック・重複参加防止・主催者への通知送信を含む。

## 変更内容

- `joinEvent` / `cancelParticipation` Server Action を新規作成（`apps/web/src/lib/actions/participation.ts`）
  - 定員チェック（`maxParticipants` vs 参加者数）
  - 開催前チェック（`startAt > now`）
  - 重複参加防止（既存レコードがある場合は UPDATE）
  - 参加表明時に主催者へ `participation_received` 通知を送信
- `ParticipationButton` クライアントコンポーネントを追加（`useTransition` + `router.refresh()`）
  - 状態: 未参加 / 参加中 / 定員満 / 開催終了 の 4 状態
- `getEventDetail` に `participantCount` / `maxParticipants` を追加
- `sendNotification` ヘルパーを新規作成（`apps/web/src/lib/notify.ts`）
- `NOTIFICATION_TYPES` に `PARTICIPATION_RECEIVED` を追加
- `ja.json` / `en.json` に参加ボタン用翻訳キーを追加

## 関連 Issue

Closes #60

## 確認方法

- [ ] イベント詳細ページで「参加する」ボタンが表示される（未参加状態）
- [ ] 参加ボタンをクリックすると「参加予定」に切り替わる
- [ ] 「参加をキャンセル」をクリックすると「キャンセル済み」に切り替わる
- [ ] 定員満のイベントでは「定員満」ボタンが表示される（disabled）
- [ ] 終了済みイベントでは「終了済み」ボタンが表示される（disabled）

🤖 Generated with [Claude Code](https://claude.com/claude-code)