### PR TITLE
feat: API実行後のトースト通知を実装

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -203,7 +203,9 @@
     "error_slug_taken": "This slug is already taken",
     "error_already_applied": "You already have a pending application",
     "success_title": "Application Received",
-    "success_description": "An admin will review your application and contact you."
+    "success_description": "An admin will review your application and contact you.",
+    "toast_success": "Application submitted",
+    "toast_error": "Something went wrong. Please try again"
   },
   "admin": {
     "title": "Admin Dashboard",
@@ -223,7 +225,10 @@
     "reject_note": "Rejection Note (optional)",
     "reject_note_placeholder": "Reason for rejection",
     "approve_confirm": "Approve this application? An organization will be created.",
-    "reject_confirm": "Reject this application?"
+    "reject_confirm": "Reject this application?",
+    "toast_approve_success": "Application approved",
+    "toast_reject_success": "Application rejected",
+    "toast_error": "Something went wrong. Please try again"
   },
   "terms": {
     "link_text": "Terms of Service",
@@ -253,7 +258,11 @@
     "error_invalid": "Please check your inputs",
     "error_not_found": "Event not found",
     "error_forbidden": "This action is not allowed",
-    "error_unauthorized": "Please sign in"
+    "error_unauthorized": "Please sign in",
+    "toast_draft_saved": "Draft saved",
+    "toast_submitted": "Submitted for approval",
+    "toast_published": "Event published",
+    "toast_error": "Something went wrong. Please try again"
   },
   "event_create": {
     "title": "Create Event",
@@ -271,7 +280,9 @@
     "error_unauthorized": "Please sign in",
     "error_forbidden": "You don't have permission to create events",
     "error_invalid": "Please check your inputs",
-    "error_unknown": "An error occurred. Please try again"
+    "error_unknown": "An error occurred. Please try again",
+    "toast_success": "Event draft saved",
+    "toast_error": "Something went wrong. Please try again"
   },
   "event_detail": {
     "back": "Back to Dashboard",
@@ -291,7 +302,13 @@
     "full_capacity": "Full",
     "event_ended": "Ended",
     "joining": "Processing...",
-    "cancelling": "Processing..."
+    "cancelling": "Processing...",
+    "toast_join_success": "You've joined the event",
+    "toast_cancel_success": "Participation cancelled",
+    "toast_already_registered": "You're already registered",
+    "toast_full_capacity": "This event is full",
+    "toast_event_ended": "This event has already ended",
+    "toast_error": "Something went wrong. Please try again"
   },
   "privacy": {
     "title": "Privacy Policy",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -203,7 +203,9 @@
     "error_slug_taken": "このスラッグはすでに使用されています",
     "error_already_applied": "すでに申請中です",
     "success_title": "申請を受け付けました",
-    "success_description": "管理者が内容を確認後、ご連絡いたします。"
+    "success_description": "管理者が内容を確認後、ご連絡いたします。",
+    "toast_success": "申請を送信しました",
+    "toast_error": "エラーが発生しました。もう一度お試しください"
   },
   "admin": {
     "title": "管理者画面",
@@ -223,7 +225,10 @@
     "reject_note": "却下理由（任意）",
     "reject_note_placeholder": "却下理由を入力してください",
     "approve_confirm": "この申請を承認しますか？承認すると組織が作成されます。",
-    "reject_confirm": "この申請を却下しますか？"
+    "reject_confirm": "この申請を却下しますか？",
+    "toast_approve_success": "申請を承認しました",
+    "toast_reject_success": "申請を却下しました",
+    "toast_error": "エラーが発生しました。もう一度お試しください"
   },
   "terms": {
     "link_text": "利用規約",
@@ -253,7 +258,11 @@
     "error_invalid": "入力内容を確認してください",
     "error_not_found": "イベントが見つかりません",
     "error_forbidden": "この操作は許可されていません",
-    "error_unauthorized": "ログインが必要です"
+    "error_unauthorized": "ログインが必要です",
+    "toast_draft_saved": "下書きを保存しました",
+    "toast_submitted": "申請しました",
+    "toast_published": "公開しました",
+    "toast_error": "エラーが発生しました。もう一度お試しください"
   },
   "event_create": {
     "title": "イベントを作成",
@@ -271,7 +280,9 @@
     "error_unauthorized": "ログインが必要です",
     "error_forbidden": "イベント作成権限がありません",
     "error_invalid": "入力内容を確認してください",
-    "error_unknown": "エラーが発生しました。もう一度お試しください"
+    "error_unknown": "エラーが発生しました。もう一度お試しください",
+    "toast_success": "イベントを下書き保存しました",
+    "toast_error": "エラーが発生しました。もう一度お試しください"
   },
   "event_detail": {
     "back": "ダッシュボードへ戻る",
@@ -291,7 +302,13 @@
     "full_capacity": "定員満",
     "event_ended": "終了済み",
     "joining": "処理中...",
-    "cancelling": "処理中..."
+    "cancelling": "処理中...",
+    "toast_join_success": "イベントに参加しました",
+    "toast_cancel_success": "参加をキャンセルしました",
+    "toast_already_registered": "すでに参加済みです",
+    "toast_full_capacity": "定員に達しています",
+    "toast_event_ended": "開催済みのイベントです",
+    "toast_error": "エラーが発生しました。もう一度お試しください"
   },
   "privacy": {
     "title": "プライバシーポリシー",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.0.8",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/apps/web/src/app/[locale]/admin/applications/review-actions.tsx
+++ b/apps/web/src/app/[locale]/admin/applications/review-actions.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useActionState } from "react";
+import { useActionState, useEffect } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { approveApplication, rejectApplication } from "./actions";
@@ -33,15 +34,26 @@ export function ReviewActions({
   const [approveState, approveAction, isApproving] = useActionState(approveApplication, null);
   const [rejectState, rejectAction, isRejecting] = useActionState(rejectApplication, null);
 
+  useEffect(() => {
+    if (!approveState) return;
+    if ((approveState as { error?: string }).error) {
+      toast.error(t("toast_error"));
+    } else if ((approveState as { ok?: boolean }).ok) {
+      toast.success(t("toast_approve_success"));
+    }
+  }, [approveState, t]);
+
+  useEffect(() => {
+    if (!rejectState) return;
+    if ((rejectState as { error?: string }).error) {
+      toast.error(t("toast_error"));
+    } else if ((rejectState as { ok?: boolean }).ok) {
+      toast.success(t("toast_reject_success"));
+    }
+  }, [rejectState, t]);
+
   return (
     <div className="space-y-3 border-t pt-3">
-      {(approveState as { error?: string } | null)?.error && (
-        <p className="text-sm text-destructive">{(approveState as { error: string }).error}</p>
-      )}
-      {(rejectState as { error?: string } | null)?.error && (
-        <p className="text-sm text-destructive">{(rejectState as { error: string }).error}</p>
-      )}
-
       <form action={approveAction} className="inline-block mr-2">
         <input type="hidden" name="applicationId" value={applicationId} />
         <input type="hidden" name="applicantUserId" value={applicantUserId} />

--- a/apps/web/src/app/[locale]/dashboard/apply/apply-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/apply/apply-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useActionState } from "react";
+import { useActionState, useEffect } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -15,6 +16,15 @@ type Props = {
 export function ApplyForm({ userId, locale }: Props) {
   const t = useTranslations("apply");
   const [state, action, isPending] = useActionState(submitApplication, null);
+
+  useEffect(() => {
+    if (!state) return;
+    if (state.success) {
+      toast.success(t("toast_success"));
+    } else {
+      toast.error(t("toast_error"));
+    }
+  }, [state, t]);
 
   if (state?.success) {
     return (

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -3,6 +3,7 @@
 import { useTransition, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -52,8 +53,10 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
       const result = await updateEventDraft(eventId, formData);
       if ("error" in result) {
         setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        toast.error(t("toast_error"));
         return;
       }
+      toast.success(t("toast_draft_saved"));
       router.refresh();
     });
   }
@@ -64,8 +67,10 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
       const result = await submitEvent(eventId);
       if ("error" in result) {
         setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        toast.error(t("toast_error"));
         return;
       }
+      toast.success(t("toast_submitted"));
       router.push(`/${locale}/dashboard`);
     });
   }
@@ -76,8 +81,10 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
       const result = await publishEvent(eventId);
       if ("error" in result) {
         setError(t(`error_${result.error}` as Parameters<typeof t>[0]));
+        toast.error(t("toast_error"));
         return;
       }
+      toast.success(t("toast_published"));
       router.push(`/${locale}/dashboard/event/${eventId}`);
     });
   }

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/participation-button.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/participation-button.tsx
@@ -2,6 +2,8 @@
 
 import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { joinEvent, cancelParticipation } from '@/lib/actions/participation';
 
@@ -32,17 +34,33 @@ export function ParticipationButton({
 }: Props) {
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
+  const t = useTranslations('event_detail');
 
   const handleJoin = () => {
     startTransition(async () => {
-      await joinEvent(eventId);
+      const result = await joinEvent(eventId);
+      if ('error' in result) {
+        const errorKey = {
+          already_registered: 'toast_already_registered',
+          full_capacity: 'toast_full_capacity',
+          event_ended: 'toast_event_ended',
+        }[result.error] ?? 'toast_error';
+        toast.error(t(errorKey as Parameters<typeof t>[0]));
+        return;
+      }
+      toast.success(t('toast_join_success'));
       router.refresh();
     });
   };
 
   const handleCancel = () => {
     startTransition(async () => {
-      await cancelParticipation(eventId);
+      const result = await cancelParticipation(eventId);
+      if ('error' in result) {
+        toast.error(t('toast_error'));
+        return;
+      }
+      toast.success(t('toast_cancel_success'));
       router.refresh();
     });
   };

--- a/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
@@ -3,6 +3,7 @@
 import { useTransition, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -39,8 +40,10 @@ export function EventCreateForm({ bars, locale }: Props) {
           | "error_invalid"
           | "error_unknown";
         setError(t(key));
+        toast.error(t("toast_error"));
         return;
       }
+      toast.success(t("toast_success"));
       router.push(`/${locale}/dashboard/event/${result.eventId}`);
     });
   }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
+import { Toaster } from "sonner";
 import "../globals.css";
 
 const geistSans = Geist({
@@ -50,6 +51,7 @@ export default async function LocaleLayout({
       <body className="min-h-full flex flex-col">
         <NextIntlClientProvider messages={messages}>
           {children}
+          <Toaster position="bottom-center" richColors />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       shadcn:
         specifier: ^4.0.8
         version: 4.0.8(@types/node@20.19.37)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4271,6 +4274,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8961,6 +8970,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## 概要

sonner を導入し、Server Action の実行後に画面下部へトースト通知を表示するよう実装した。
成功時は緑のトースト、失敗時は赤のトーストを `position="bottom-center"` で表示する。

## 変更内容

- `sonner` パッケージを追加
- `layout.tsx`: `<Toaster position="bottom-center" richColors />` を追加
- `participation-button.tsx`: 参加・キャンセル成功/エラー時のトースト
- `review-actions.tsx`: 承認・却下成功/エラー時のトースト（`useEffect` で state 監視）
- `apply-form.tsx`: 申請送信成功/エラー時のトースト
- `event-create-form.tsx`: 下書き保存成功/エラー時のトースト
- `event-edit-form.tsx`: 下書き保存・申請・公開の成功/エラー時のトースト
- `ja.json` / `en.json`: `toast_*` 翻訳キーを追加

## 関連 Issue

Closes #67

## 確認方法

- [ ] イベント詳細ページで「参加する」をクリックし、成功トーストが表示される
- [ ] 同ページで「参加をキャンセル」をクリックし、成功トーストが表示される
- [ ] イベント編集ページで「下書き保存」し、成功トーストが表示される
- [ ] 管理者画面で「承認する」「却下する」をクリックし、トーストが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)