### PR TITLE
feat: 下書き保存ボタンにスピナー表示を追加

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -4,6 +4,7 @@ import { useTransition, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -162,6 +163,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
 
           <div className="flex flex-col gap-2 pt-2">
             <Button type="submit" variant="outline" disabled={isPending}>
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {isPending ? t("submitting") : t("save_draft")}
             </Button>
 
@@ -171,6 +173,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
                 disabled={isPending || !hasDatetime}
                 onClick={handlePublish}
               >
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 {isPending ? t("submitting") : t("publish")}
               </Button>
             ) : (
@@ -179,6 +182,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
                 disabled={isPending || !hasDatetime}
                 onClick={handleSubmit}
               >
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 {isPending ? t("submitting") : t("submit")}
               </Button>
             )}


### PR DESCRIPTION
## 概要

イベント編集フォームの下書き保存・申請・公開ボタンに、処理中を示す `Loader2` スピナーを追加した。
`isPending` が `true` の間、ボタン左側にスピナーが表示される。

## 変更内容

- `event-edit-form.tsx`: `lucide-react` の `Loader2` を import
- 下書き保存・申請・公開の3ボタンに `isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />` を追加

## 関連 Issue

Closes #68

## 確認方法

- [ ] イベント編集ページで「下書き保存」をクリックし、スピナーが回転する
- [ ] 申請ボタン・公開ボタンでも同様にスピナーが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)