### PR TITLE
feat: 主催履歴の公開/非公開設定・CSV エクスポート・プロフィールページを実装

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -165,6 +165,11 @@
     "participation_status_cancelled": "Cancelled",
     "upcoming_participations_title": "Upcoming Events",
     "upcoming_participations_empty": "No upcoming events.",
+    "organizer_history_public": "Public",
+    "organizer_history_private": "Private",
+    "organizer_history_toggle_public": "Make public",
+    "organizer_history_toggle_private": "Make private",
+    "organizer_history_csv": "Download CSV",
     "account_settings": {
       "title": "Account Settings",
       "withdrawal_section_title": "Delete Account",
@@ -328,6 +333,11 @@
         "content": "We do not share your personal information with third parties without your consent, except as required by law."
       }
     }
+  },
+  "profile": {
+    "title": "{name}'s Profile",
+    "organizer_history_title": "Organizer History",
+    "organizer_history_empty": "No public organizer history"
   },
   "terms_page": {
     "title": "Terms of Service",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -165,6 +165,11 @@
     "participation_status_cancelled": "キャンセル済み",
     "upcoming_participations_title": "参加予定イベント",
     "upcoming_participations_empty": "参加予定のイベントはありません",
+    "organizer_history_public": "公開",
+    "organizer_history_private": "非公開",
+    "organizer_history_toggle_public": "公開にする",
+    "organizer_history_toggle_private": "非公開にする",
+    "organizer_history_csv": "CSV ダウンロード",
     "account_settings": {
       "title": "アカウント設定",
       "withdrawal_section_title": "退会",
@@ -328,6 +333,11 @@
         "content": "法令に基づく場合を除き、ユーザーの同意なく個人情報を第三者に提供することはありません。"
       }
     }
+  },
+  "profile": {
+    "title": "{name} のプロフィール",
+    "organizer_history_title": "主催イベント履歴",
+    "organizer_history_empty": "公開されている主催履歴はありません"
   },
   "terms_page": {
     "title": "利用規約",

--- a/apps/web/src/app/[locale]/dashboard/organizer-history-actions.ts
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history-actions.ts
@@ -1,0 +1,41 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getLocale } from 'next-intl/server';
+import { getUser, getDbUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { events } from '@e-be/db/schema';
+import { eq, and, isNull, lt } from 'drizzle-orm';
+
+export async function toggleEventPublicAction(
+  eventId: string,
+  isPublic: boolean
+): Promise<{ error?: string }> {
+  const [, dbUser] = await Promise.all([getUser(), getDbUser()]);
+  if (!dbUser) return { error: 'unauthorized' };
+
+  const now = new Date();
+
+  // 自分の completed 相当（published かつ終了済み）イベントのみ操作可
+  const rows = await db
+    .select({ id: events.id })
+    .from(events)
+    .where(
+      and(
+        eq(events.id, eventId),
+        eq(events.userId, dbUser.id),
+        eq(events.status, 'published'),
+        lt(events.endAt, now),
+        isNull(events.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) return { error: 'not_found' };
+
+  await db.update(events).set({ isPublic }).where(eq(events.id, eventId));
+
+  const locale = await getLocale();
+  revalidatePath(`/${locale}/dashboard`);
+  return {};
+}

--- a/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { toggleEventPublicAction } from './organizer-history-actions';
+
+type Props = {
+  event: {
+    id: string;
+    title: string | null;
+    startAt: string | null;
+    status: string;
+    orgName: string;
+    isPublic: boolean;
+  };
+  locale: string;
+};
+
+export function OrganizerHistoryItem({ event, locale }: Props) {
+  const t = useTranslations('dashboard');
+  const [isPublic, setIsPublic] = useState(event.isPublic);
+  const [isPending, startTransition] = useTransition();
+
+  const isCompleted = event.status === 'published';
+
+  const statusKey =
+    event.status === 'cancelled'
+      ? 'event_status_cancelled'
+      : event.status === 'rejected'
+        ? 'event_status_rejected'
+        : 'event_status_published_ended';
+
+  const handleToggle = (checked: boolean) => {
+    setIsPublic(checked);
+    startTransition(async () => {
+      const result = await toggleEventPublicAction(event.id, checked);
+      if (result.error) {
+        // 失敗時は元に戻す
+        setIsPublic(!checked);
+      }
+    });
+  };
+
+  return (
+    <li className="flex items-center justify-between gap-3 py-3">
+      <div className="min-w-0">
+        <p className="truncate font-medium">{event.title ?? '—'}</p>
+        <p className="text-xs text-muted-foreground">{event.orgName}</p>
+        <p className="text-xs text-muted-foreground">
+          {event.startAt
+            ? new Date(event.startAt).toLocaleDateString(locale, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })
+            : '—'}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {isCompleted && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              {isPublic ? t('organizer_history_public') : t('organizer_history_private')}
+            </span>
+            <Switch
+              checked={isPublic}
+              onCheckedChange={handleToggle}
+              disabled={isPending}
+              aria-label={isPublic ? t('organizer_history_toggle_private') : t('organizer_history_toggle_public')}
+            />
+          </div>
+        )}
+        <Badge
+          variant={
+            event.status === 'cancelled' || event.status === 'rejected'
+              ? 'secondary'
+              : 'outline'
+          }
+        >
+          {t(statusKey)}
+        </Badge>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/organizer-history/csv/route.ts
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history/csv/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server';
+import { getUser, getDbUser } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { events, organizations, eventParticipations } from '@e-be/db/schema';
+import { eq, and, isNull, or, lt, count } from 'drizzle-orm';
+
+export async function GET() {
+  const [, dbUser] = await Promise.all([getUser(), getDbUser()]);
+  if (!dbUser) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const now = new Date();
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      orgName: organizations.name,
+      status: events.status,
+      endAt: events.endAt,
+    })
+    .from(events)
+    .innerJoin(organizations, eq(events.orgId, organizations.id))
+    .where(
+      and(
+        eq(events.userId, dbUser.id),
+        isNull(events.deletedAt),
+        or(
+          and(eq(events.status, 'published'), lt(events.endAt, now)),
+          eq(events.status, 'cancelled'),
+          eq(events.status, 'rejected')
+        )
+      )
+    )
+    .orderBy(events.startAt);
+
+  // 参加者数を一括取得
+  const eventIds = rows.map((r) => r.id);
+  const participantCounts: Record<string, number> = {};
+  if (eventIds.length > 0) {
+    const counts = await db
+      .select({
+        eventId: eventParticipations.eventId,
+        total: count(),
+      })
+      .from(eventParticipations)
+      .where(
+        and(
+          eq(eventParticipations.status, 'registered'),
+          isNull(eventParticipations.deletedAt)
+        )
+      )
+      .groupBy(eventParticipations.eventId);
+    for (const c of counts) {
+      participantCounts[c.eventId] = c.total;
+    }
+  }
+
+  const header = 'イベント名,開催日,バー名,参加者数,ステータス\n';
+  const csvRows = rows.map((row) => {
+    const title = `"${(row.title ?? '').replace(/"/g, '""')}"`;
+    const date = row.startAt ? row.startAt.toLocaleDateString('ja-JP') : '';
+    const bar = `"${row.orgName.replace(/"/g, '""')}"`;
+    const participants = participantCounts[row.id] ?? 0;
+    const resolvedStatus =
+      row.status === 'published' && row.endAt && row.endAt < now
+        ? '完了'
+        : row.status === 'cancelled'
+          ? 'キャンセル'
+          : row.status === 'rejected'
+            ? '却下'
+            : row.status;
+    return `${title},${date},${bar},${participants},${resolvedStatus}`;
+  });
+
+  const csv = '\uFEFF' + header + csvRows.join('\n');
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="organizer-history.csv"',
+    },
+  });
+}

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { operatorApplications } from "@e-be/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
 import { EventCalendar } from "@/components/event-calendar";
 import { getEventsForCalendar, getMyDraftEvents, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations } from "@/lib/events";
+import { OrganizerHistoryItem } from "./organizer-history-item";
 
 const USER_TYPE_VARIANT = {
   user: "secondary",
@@ -98,7 +99,18 @@ export default async function DashboardPage() {
             {userType === "user" && (
               <Card>
                 <CardHeader>
-                  <CardTitle>{t("organizer_history_title")}</CardTitle>
+                  <div className="flex items-center justify-between">
+                    <CardTitle>{t("organizer_history_title")}</CardTitle>
+                    {organizerHistory.length > 0 && (
+                      <a
+                        href={`/${locale}/dashboard/organizer-history/csv`}
+                        download
+                        className="inline-flex min-h-9 items-center rounded-md border border-border bg-background px-3 text-xs font-medium transition-colors hover:bg-muted"
+                      >
+                        {t("organizer_history_csv")}
+                      </a>
+                    )}
+                  </div>
                 </CardHeader>
                 <CardContent>
                   {organizerHistory.length === 0 ? (
@@ -107,42 +119,9 @@ export default async function DashboardPage() {
                     </p>
                   ) : (
                     <ul className="divide-y">
-                      {organizerHistory.map((event) => {
-                        const statusKey =
-                          event.status === "cancelled"
-                            ? "event_status_cancelled"
-                            : event.status === "rejected"
-                              ? "event_status_rejected"
-                              : "event_status_published_ended";
-                        return (
-                          <li key={event.id} className="flex items-center justify-between gap-3 py-3">
-                            <div className="min-w-0">
-                              <p className="truncate font-medium">
-                                {event.title ?? "—"}
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {event.startAt
-                                  ? new Date(event.startAt).toLocaleDateString(locale, {
-                                      year: "numeric",
-                                      month: "short",
-                                      day: "numeric",
-                                    })
-                                  : "—"}
-                              </p>
-                            </div>
-                            <Badge
-                              variant={
-                                event.status === "cancelled" || event.status === "rejected"
-                                  ? "secondary"
-                                  : "outline"
-                              }
-                              className="shrink-0"
-                            >
-                              {t(statusKey)}
-                            </Badge>
-                          </li>
-                        );
-                      })}
+                      {organizerHistory.map((event) => (
+                        <OrganizerHistoryItem key={event.id} event={event} locale={locale} />
+                      ))}
                     </ul>
                   )}
                 </CardContent>

--- a/apps/web/src/app/[locale]/users/[userId]/page.tsx
+++ b/apps/web/src/app/[locale]/users/[userId]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from 'next/navigation';
+import { getTranslations, getLocale } from 'next-intl/server';
+import { eq, and, isNull } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { users } from '@e-be/db/schema';
+import { getPublicOrganizerHistory } from '@/lib/events';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+type Props = {
+  params: Promise<{ userId: string }>;
+};
+
+export default async function UserProfilePage({ params }: Props) {
+  const { userId } = await params;
+  const [t, locale] = await Promise.all([getTranslations('profile'), getLocale()]);
+
+  const rows = await db
+    .select({ id: users.id, name: users.name })
+    .from(users)
+    .where(and(eq(users.id, userId), isNull(users.deletedAt)))
+    .limit(1);
+
+  if (rows.length === 0) notFound();
+
+  const profileUser = rows[0];
+  const history = await getPublicOrganizerHistory(userId);
+
+  return (
+    <main className="p-4 md:p-6">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-2xl font-bold">
+          {t('title', { name: profileUser.name ?? userId })}
+        </h1>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('organizer_history_title')}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {history.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                {t('organizer_history_empty')}
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {history.map((event) => (
+                  <li key={event.id} className="flex items-center justify-between gap-3 py-3">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{event.title ?? '—'}</p>
+                      <p className="text-xs text-muted-foreground">{event.orgName}</p>
+                    </div>
+                    <p className="shrink-0 text-sm text-muted-foreground">
+                      {event.startAt
+                        ? new Date(event.startAt).toLocaleDateString(locale, {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          })
+                        : '—'}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -215,6 +215,8 @@ export type OrganizerHistoryItem = {
   endAt: string | null;
   status: string;
   orgId: string;
+  orgName: string;
+  isPublic: boolean;
 };
 
 /**
@@ -234,8 +236,11 @@ export async function getOrganizerHistory(userId: string): Promise<OrganizerHist
       endAt: events.endAt,
       status: events.status,
       orgId: events.orgId,
+      orgName: organizations.name,
+      isPublic: events.isPublic,
     })
     .from(events)
+    .innerJoin(organizations, eq(events.orgId, organizations.id))
     .where(
       and(
         eq(events.userId, userId),
@@ -258,6 +263,52 @@ export async function getOrganizerHistory(userId: string): Promise<OrganizerHist
     endAt: row.endAt?.toISOString() ?? null,
     status: row.status,
     orgId: row.orgId,
+    orgName: row.orgName,
+    isPublic: row.isPublic,
+  }));
+}
+
+export type PublicOrganizerHistoryItem = {
+  id: string;
+  title: string | null;
+  startAt: string | null;
+  orgName: string;
+};
+
+/**
+ * プロフィールページ用に公開設定の主催履歴を取得する。
+ * - is_public = true かつ published かつ終了済み（completed 相当）のみ
+ * - 未ログインでも閲覧可能
+ * - 新しい順（startAt DESC）で返す
+ */
+export async function getPublicOrganizerHistory(userId: string): Promise<PublicOrganizerHistoryItem[]> {
+  const now = new Date();
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      orgName: organizations.name,
+    })
+    .from(events)
+    .innerJoin(organizations, eq(events.orgId, organizations.id))
+    .where(
+      and(
+        eq(events.userId, userId),
+        eq(events.isPublic, true),
+        eq(events.status, "published"),
+        lt(events.endAt, now),
+        isNull(events.deletedAt)
+      )
+    )
+    .orderBy(desc(events.startAt));
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    startAt: row.startAt?.toISOString() ?? null,
+    orgName: row.orgName,
   }));
 }
 

--- a/packages/db/drizzle/0002_shallow_namora.sql
+++ b/packages/db/drizzle/0002_shallow_namora.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "is_public" boolean DEFAULT true NOT NULL;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1470 @@
+{
+  "id": "fefb88d4-8270-4f03-b44e-199852778602",
+  "prevId": "57a1e76c-1d6f-4bb3-9288-3d0b9beac966",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_org_id_organizations_id_fk": {
+          "name": "audit_logs_org_id_organizations_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.bar_blocks": {
+      "name": "bar_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bar_blocks_bar_id_organizations_id_fk": {
+          "name": "bar_blocks_bar_id_organizations_id_fk",
+          "tableFrom": "bar_blocks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.bar_host_permissions": {
+      "name": "bar_host_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bar_host_permissions_bar_id_organizations_id_fk": {
+          "name": "bar_host_permissions_bar_id_organizations_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bar_host_permissions_user_id_users_id_fk": {
+          "name": "bar_host_permissions_user_id_users_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bar_host_permissions_granted_by_users_id_fk": {
+          "name": "bar_host_permissions_granted_by_users_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_slug_unique": {
+          "name": "companies_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.coupons": {
+      "name": "coupons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_org_id_organizations_id_fk": {
+          "name": "coupons_org_id_organizations_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_participations": {
+      "name": "event_participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        }
+      },
+      "indexes": {
+        "unique_event_participation": {
+          "name": "unique_event_participation",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_participations_event_id_events_id_fk": {
+          "name": "event_participations_event_id_events_id_fk",
+          "tableFrom": "event_participations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_participations_user_id_users_id_fk": {
+          "name": "event_participations_user_id_users_id_fk",
+          "tableFrom": "event_participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_org_id_organizations_id_fk": {
+          "name": "events_org_id_organizations_id_fk",
+          "tableFrom": "events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_user_id_users_id_fk": {
+          "name": "events_user_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.fc_relationships": {
+      "name": "fc_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "franchisor_org_id": {
+          "name": "franchisor_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "franchisee_org_id": {
+          "name": "franchisee_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fc_relationships_franchisor_org_id_organizations_id_fk": {
+          "name": "fc_relationships_franchisor_org_id_organizations_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "franchisor_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fc_relationships_franchisee_org_id_organizations_id_fk": {
+          "name": "fc_relationships_franchisee_org_id_organizations_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "franchisee_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fc_relationships_granted_by_users_id_fk": {
+          "name": "fc_relationships_granted_by_users_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.operator_applications": {
+      "name": "operator_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_name": {
+          "name": "org_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "operator_applications_user_id_users_id_fk": {
+          "name": "operator_applications_user_id_users_id_fk",
+          "tableFrom": "operator_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "operator_applications_reviewed_by_users_id_fk": {
+          "name": "operator_applications_reviewed_by_users_id_fk",
+          "tableFrom": "operator_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "unique_org_owner": {
+          "name": "unique_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_org_id_organizations_id_fk": {
+          "name": "organization_members_org_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_color": {
+          "name": "image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_company_id_companies_id_fk": {
+          "name": "organizations_company_id_companies_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.user_coupons": {
+      "name": "user_coupons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_coupons_user_id_users_id_fk": {
+          "name": "user_coupons_user_id_users_id_fk",
+          "tableFrom": "user_coupons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_coupons_coupon_id_coupons_id_fk": {
+          "name": "user_coupons_coupon_id_coupons_id_fk",
+          "tableFrom": "user_coupons",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "published",
+        "cancelled",
+        "rejected"
+      ]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    },
+    "public.participation_status": {
+      "name": "participation_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "cancelled"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "premium"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "venue_user",
+        "system_user"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774063586199,
       "tag": "0001_violet_gamora",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1774086463398,
+      "tag": "0002_shallow_namora",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   pgEnum,
   uniqueIndex,
+  boolean,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -141,6 +142,7 @@ export const events = pgTable('events', {
   maxParticipants: integer('max_participants'),
   location: text('location'),
   chargeAmount: integer('charge_amount'), // チャージ料（円）null = 未設定
+  isPublic: boolean('is_public').default(true).notNull(),
 });
 
 export const barHostPermissions = pgTable('bar_host_permissions', {


### PR DESCRIPTION
## 概要

ユーザーダッシュボードの主催履歴に公開/非公開トグルと CSV エクスポートを追加し、プロフィールページ（`/users/[userId]`）を新設します。

## 変更内容

- `events` テーブルに `is_public` カラムを追加（boolean、デフォルト: `true`）
- Drizzle マイグレーション `0002_shallow_namora.sql` を追加
- `getOrganizerHistory` にバー名・`isPublic` を追加、`getPublicOrganizerHistory` を新規追加
- ダッシュボード主催履歴: バー名・公開トグル（Switch）・CSV ダウンロードボタンを追加
- `toggleEventPublicAction` Server Action（completed イベントのみ操作可・所有者チェック）
- CSV エクスポート Route Handler（イベント名・開催日・バー名・参加者数・ステータス）
- プロフィールページ `/users/[userId]` を新設（未ログインでも閲覧可能、公開済み completed のみ表示）
- shadcn/ui `Switch` コンポーネントを追加
- 翻訳キー追加（ja/en 両方）

## 関連 Issue

Closes #62

## 確認方法

- [ ] ダッシュボードの「主催イベント履歴」にトグルと「CSV ダウンロード」が表示される
- [ ] トグルで公開/非公開を切り替えられる（リロード後も状態が維持される）
- [ ] CSV ダウンロードでイベント一覧が取得できる
- [ ] `/ja/users/{userId}` でプロフィールページが表示される（未ログインでもアクセス可）
- [ ] プロフィールページには `is_public=true` の completed イベントのみ表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)