### PR TITLE
feat: 「所属組織」表示を一般ユーザーにはデフォルト非表示にする

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -3,9 +3,6 @@ import { getUser, getUserOrgs, getUserType } from "@/lib/auth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { db } from "@/lib/db";
-import { operatorApplications } from "@e-be/db/schema";
-import { eq, and, isNull } from "drizzle-orm";
 import { EventCalendar } from "@/components/event-calendar";
 import { getEventsForCalendar, getMyDraftEvents, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations } from "@/lib/events";
 import { OrganizerHistoryItem } from "./organizer-history-item";
@@ -35,30 +32,17 @@ export default async function DashboardPage() {
   ]);
 
   // userType === 'user' のみ必要なデータを並行取得
-  let hasPendingApplication = false;
   let organizerHistory: Awaited<ReturnType<typeof getOrganizerHistory>> = [];
   let participationHistory: Awaited<ReturnType<typeof getParticipationHistory>> = [];
   let upcomingParticipations: Awaited<ReturnType<typeof getUpcomingParticipations>> = [];
   let myDraftEvents: Awaited<ReturnType<typeof getMyDraftEvents>> = [];
   if (userType === "user") {
-    const [pendingResult, historyResult, participationResult, upcomingResult, draftResult] = await Promise.all([
-      db
-        .select({ id: operatorApplications.id })
-        .from(operatorApplications)
-        .where(
-          and(
-            eq(operatorApplications.userId, user.id),
-            eq(operatorApplications.status, "pending"),
-            isNull(operatorApplications.deletedAt)
-          )
-        )
-        .limit(1),
+    const [historyResult, participationResult, upcomingResult, draftResult] = await Promise.all([
       getOrganizerHistory(user.id),
       getParticipationHistory(user.id),
       getUpcomingParticipations(user.id),
       getMyDraftEvents(user.id),
     ]);
-    hasPendingApplication = pendingResult.length > 0;
     organizerHistory = historyResult;
     participationHistory = participationResult;
     upcomingParticipations = upcomingResult;
@@ -297,30 +281,12 @@ export default async function DashboardPage() {
               </Card>
             )}
 
-            <Card>
-              <CardHeader>
-                <CardTitle>{t("orgs_title")}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {userOrgs.length === 0 ? (
-                  <div className="space-y-4 text-center py-4">
-                    <p className="text-sm text-muted-foreground">{t("no_orgs")}</p>
-                    {userType === "user" && (
-                      hasPendingApplication ? (
-                        <Badge variant="secondary" className="text-sm px-4 py-2">
-                          {t("application_pending")}
-                        </Badge>
-                      ) : (
-                        <Link
-                          href={`/${locale}/dashboard/apply`}
-                          className="inline-flex min-h-11 items-center rounded-lg border border-border bg-background px-4 text-[0.8rem] font-medium transition-all hover:bg-muted"
-                        >
-                          {t("apply_operator")}
-                        </Link>
-                      )
-                    )}
-                  </div>
-                ) : (
+            {userOrgs.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>{t("orgs_title")}</CardTitle>
+                </CardHeader>
+                <CardContent>
                   <ul className="divide-y">
                     {userOrgs.map(({ org, role }) => (
                       <li key={org.id} className="flex items-center justify-between py-3 gap-3">
@@ -342,9 +308,9 @@ export default async function DashboardPage() {
                       </li>
                     ))}
                   </ul>
-                )}
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/app/[locale]/users/[userId]/page.tsx
+++ b/apps/web/src/app/[locale]/users/[userId]/page.tsx
@@ -47,7 +47,6 @@ export default async function UserProfilePage({ params }: Props) {
                   <li key={event.id} className="flex items-center justify-between gap-3 py-3">
                     <div className="min-w-0">
                       <p className="truncate font-medium">{event.title ?? '—'}</p>
-                      <p className="text-xs text-muted-foreground">{event.orgName}</p>
                     </div>
                     <p className="shrink-0 text-sm text-muted-foreground">
                       {event.startAt

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -272,7 +272,6 @@ export type PublicOrganizerHistoryItem = {
   id: string;
   title: string | null;
   startAt: string | null;
-  orgName: string;
 };
 
 /**
@@ -289,10 +288,8 @@ export async function getPublicOrganizerHistory(userId: string): Promise<PublicO
       id: events.id,
       title: events.title,
       startAt: events.startAt,
-      orgName: organizations.name,
     })
     .from(events)
-    .innerJoin(organizations, eq(events.orgId, organizations.id))
     .where(
       and(
         eq(events.userId, userId),
@@ -308,7 +305,6 @@ export async function getPublicOrganizerHistory(userId: string): Promise<PublicO
     id: row.id,
     title: row.title,
     startAt: row.startAt?.toISOString() ?? null,
-    orgName: row.orgName,
   }));
 }
 


### PR DESCRIPTION
## Summary

- ダッシュボードの「所属組織」カードを、組織に所属しているユーザーのみに表示するよう変更（`userOrgs.length > 0` 条件を追加）
- 公開プロフィールページ（`/users/[userId]`）の主催履歴から `orgName`（組織名）表示を削除
- `getPublicOrganizerHistory` / `PublicOrganizerHistoryItem` から `orgName` フィールドを除去し、`organizations` テーブルへの不要な JOIN も削除

Closes #85

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `apps/web/src/app/[locale]/dashboard/page.tsx` | 「所属組織」カードを `userOrgs.length > 0` のときのみ表示。空状態・申請ボタンを削除。不要な DB クエリ・インポートを除去 |
| `apps/web/src/app/[locale]/users/[userId]/page.tsx` | 主催履歴の各行から orgName 表示を削除 |
| `apps/web/src/lib/events.ts` | `PublicOrganizerHistoryItem` 型・`getPublicOrganizerHistory` から `orgName` を除去。organizations JOIN を削除 |

## Test plan

- [x] 一般ユーザー（test-user）でダッシュボードを確認 → 「所属組織」カードが非表示
- [x] 公開プロフィールページで主催履歴に組織名が非表示
- [x] 事業者（test-venue）でダッシュボードを確認 → 「所属組織」カードが表示される（テストバー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)