### PR TITLE
feat: イベント申請フロー改善（日付任意化・警告表示・確認Modal）

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -279,7 +279,13 @@
     "toast_draft_saved": "Draft saved",
     "toast_submitted": "Submitted for approval",
     "toast_published": "Event published",
-    "toast_error": "Something went wrong. Please try again"
+    "toast_error": "Something went wrong. Please try again",
+    "warning_no_datetime": "No date set. Please coordinate with the venue after submitting.",
+    "submit_confirm_title": "Confirm Submission",
+    "submit_confirm_venue": "Venue",
+    "submit_confirm_datetime": "Date & Time",
+    "submit_confirm_not_set": "Not set",
+    "submit_confirm_label": "Submit"
   },
   "event_create": {
     "title": "Create Event",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -279,7 +279,13 @@
     "toast_draft_saved": "下書きを保存しました",
     "toast_submitted": "申請しました",
     "toast_published": "公開しました",
-    "toast_error": "エラーが発生しました。もう一度お試しください"
+    "toast_error": "エラーが発生しました。もう一度お試しください",
+    "warning_no_datetime": "日程が未設定です。申請後にバー側と調整してください",
+    "submit_confirm_title": "申請内容の確認",
+    "submit_confirm_venue": "会場",
+    "submit_confirm_datetime": "日時",
+    "submit_confirm_not_set": "未設定",
+    "submit_confirm_label": "申請する"
   },
   "event_create": {
     "title": "イベントを作成",

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { updateEventDraft, submitEvent, publishEvent } from "@/lib/actions/event";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import Link from "next/link";
 
 type EventData = {
@@ -40,6 +41,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
   const [error, setError] = useState<string | null>(null);
   const [startAt, setStartAt] = useState(event.startAt ?? "");
   const [endAt, setEndAt] = useState(event.endAt ?? "");
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   function handleStartAtChange(value: string) {
     setStartAt(value);
@@ -53,7 +55,8 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
   const hasDatetime = startAt !== "" && endAt !== "";
   const isDatetimeInvalid =
     hasDatetime && new Date(startAt) >= new Date(endAt);
-  const canSubmit = hasVenue && hasDatetime && !isDatetimeInvalid;
+  const canSubmit = hasVenue && !isDatetimeInvalid;
+  const canPublish = hasVenue && hasDatetime && !isDatetimeInvalid;
 
   function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -73,6 +76,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
   }
 
   function handleSubmit() {
+    setConfirmOpen(false);
     setError(null);
     startTransition(async () => {
       const result = await submitEvent(eventId);
@@ -99,6 +103,19 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
       router.push(`/${locale}/dashboard/event/${eventId}`);
     });
   }
+
+  const confirmDescription = (
+    <span className="flex flex-col gap-1 text-sm">
+      <span className="flex gap-2">
+        <span className="text-muted-foreground shrink-0">{t("submit_confirm_venue")}:</span>
+        <span>{event.orgName}</span>
+      </span>
+      <span className="flex gap-2">
+        <span className="text-muted-foreground shrink-0">{t("submit_confirm_datetime")}:</span>
+        <span>{hasDatetime ? `${startAt} 〜 ${endAt}` : t("submit_confirm_not_set")}</span>
+      </span>
+    </span>
+  );
 
   return (
     <Card>
@@ -197,6 +214,9 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
           {isDatetimeInvalid && (
             <p className="text-sm text-destructive">{t("error_invalid_range")}</p>
           )}
+          {!hasPermission && !hasDatetime && !isDatetimeInvalid && (
+            <p className="text-sm text-amber-600 dark:text-amber-400">{t("warning_no_datetime")}</p>
+          )}
 
           <div className="flex flex-col gap-2 pt-2">
             <Button type="submit" variant="outline" disabled={isPending}>
@@ -207,7 +227,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
             {hasPermission ? (
               <Button
                 type="button"
-                disabled={isPending || !canSubmit}
+                disabled={isPending || !canPublish}
                 onClick={handlePublish}
               >
                 {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -217,7 +237,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
               <Button
                 type="button"
                 disabled={isPending || !canSubmit}
-                onClick={handleSubmit}
+                onClick={() => setConfirmOpen(true)}
               >
                 {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 {isPending ? t("submitting") : t("submit")}
@@ -229,6 +249,16 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
             </Link>
           </div>
         </form>
+
+        <ConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title={t("submit_confirm_title")}
+          description={confirmDescription}
+          confirmLabel={t("submit_confirm_label")}
+          onConfirm={handleSubmit}
+          isPending={isPending}
+        />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/lib/actions/event.ts
+++ b/apps/web/src/lib/actions/event.ts
@@ -115,14 +115,15 @@ export async function submitEvent(eventId: string): Promise<ActionResult> {
   if (!target) return { error: 'not_found' };
   if (target.status !== 'draft') return { error: 'forbidden' };
   if (!target.orgId) return { error: 'venue_required' };
-  if (!target.startAt || !target.endAt) return { error: 'datetime_required' };
 
-  const now = new Date();
-  if (target.startAt <= now) return { error: 'past_date' };
-  if (target.endAt <= target.startAt) return { error: 'invalid_range' };
+  if (target.startAt && target.endAt) {
+    const now = new Date();
+    if (target.startAt <= now) return { error: 'past_date' };
+    if (target.endAt <= target.startAt) return { error: 'invalid_range' };
 
-  const conflict = await checkEventConflict(target.orgId, target.startAt, target.endAt, eventId);
-  if (conflict) return { error: 'conflict' };
+    const conflict = await checkEventConflict(target.orgId, target.startAt, target.endAt, eventId);
+    if (conflict) return { error: 'conflict' };
+  }
 
   await db.update(events).set({ status: 'pending', updatedAt: new Date() }).where(eq(events.id, eventId));
   return { ok: true };


### PR DESCRIPTION
## 概要

イベント申請時に日付が未設定でも申請できるよう変更。バーと交渉して後から日時を決めるユースケースを許容する。日付未設定の場合は警告文を表示し、申請ボタン押下時に確認 Dialog を表示する。

## 変更内容

- `submitEvent`: `datetime_required` チェックを削除（日付なしでも申請可能に）。日付がある場合のみ過去日・範囲・重複チェックを実行
- `event-edit-form.tsx`: 申請ボタンの `canSubmit` 条件から `hasDatetime` を除去。日付未設定時に警告文を表示。申請ボタン押下で `ConfirmDialog` を表示（会場名・日時を確認してから申請実行）
- `ja.json` / `en.json`: 警告文・確認 Modal のテキストキーを追加
- 公開（`hasPermission=true`）は日付必須のまま変更なし

## 関連 Issue

Closes #92

## 確認方法

- [ ] 日付未設定のイベント編集画面で「日程が未設定です。申請後にバー側と調整してください」が表示される
- [ ] 日付未設定でも「申請する」ボタンが活性化している
- [ ] 申請ボタン押下で「申請内容の確認」ダイアログが表示される
- [ ] ダイアログに会場名と日時（未設定の場合は「未設定」）が表示される
- [ ] 「申請する」ボタンで申請処理が実行される
- [ ] `end_at < start_at` の場合はボタン disabled のまま
- [ ] 公開（`hasPermission=true`）は日付必須のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)