### PR TITLE
feat: 主催イベント履歴に参加者数・チャージ料・売上列を追加 (#86)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -178,6 +178,9 @@
     "organizer_history_toggle_public": "Make public",
     "organizer_history_toggle_private": "Make private",
     "organizer_history_csv": "Download CSV",
+    "organizer_history_participants": "Participants",
+    "organizer_history_charge": "Charge",
+    "organizer_history_sales": "Sales",
     "account_settings": {
       "title": "Account Settings",
       "withdrawal_section_title": "Delete Account",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -178,6 +178,9 @@
     "organizer_history_toggle_public": "公開にする",
     "organizer_history_toggle_private": "非公開にする",
     "organizer_history_csv": "CSV ダウンロード",
+    "organizer_history_participants": "参加者数",
+    "organizer_history_charge": "チャージ料",
+    "organizer_history_sales": "売上",
     "account_settings": {
       "title": "アカウント設定",
       "withdrawal_section_title": "退会",

--- a/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
@@ -14,6 +14,8 @@ type Props = {
     status: string;
     orgName: string;
     isPublic: boolean;
+    chargeAmount: number | null;
+    participantCount: number;
   };
   locale: string;
 };
@@ -43,44 +45,69 @@ export function OrganizerHistoryItem({ event, locale }: Props) {
     });
   };
 
+  const salesAmount =
+    event.chargeAmount != null ? event.chargeAmount * event.participantCount : null;
+
   return (
-    <li className="flex items-center justify-between gap-3 py-3">
-      <div className="min-w-0">
-        <p className="truncate font-medium">{event.title ?? '—'}</p>
-        <p className="text-xs text-muted-foreground">{event.orgName}</p>
-        <p className="text-xs text-muted-foreground">
-          {event.startAt
-            ? new Date(event.startAt).toLocaleDateString(locale, {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })
-            : '—'}
-        </p>
+    <li className="py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate font-medium">{event.title ?? '—'}</p>
+          <p className="text-xs text-muted-foreground">{event.orgName}</p>
+          <p className="text-xs text-muted-foreground">
+            {event.startAt
+              ? new Date(event.startAt).toLocaleDateString(locale, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })
+              : '—'}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {isCompleted && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {isPublic ? t('organizer_history_public') : t('organizer_history_private')}
+              </span>
+              <Switch
+                checked={isPublic}
+                onCheckedChange={handleToggle}
+                disabled={isPending}
+                aria-label={isPublic ? t('organizer_history_toggle_private') : t('organizer_history_toggle_public')}
+              />
+            </div>
+          )}
+          <Badge
+            variant={
+              event.status === 'cancelled' || event.status === 'rejected'
+                ? 'secondary'
+                : 'outline'
+            }
+          >
+            {t(statusKey)}
+          </Badge>
+        </div>
       </div>
-      <div className="flex shrink-0 items-center gap-2">
-        {isCompleted && (
-          <div className="flex items-center gap-1.5">
-            <span className="text-xs text-muted-foreground">
-              {isPublic ? t('organizer_history_public') : t('organizer_history_private')}
-            </span>
-            <Switch
-              checked={isPublic}
-              onCheckedChange={handleToggle}
-              disabled={isPending}
-              aria-label={isPublic ? t('organizer_history_toggle_private') : t('organizer_history_toggle_public')}
-            />
-          </div>
-        )}
-        <Badge
-          variant={
-            event.status === 'cancelled' || event.status === 'rejected'
-              ? 'secondary'
-              : 'outline'
-          }
-        >
-          {t(statusKey)}
-        </Badge>
+      <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
+        <span className="text-xs text-muted-foreground">
+          {t('organizer_history_participants')}:{' '}
+          <span className="font-medium text-foreground">{event.participantCount}</span>
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {t('organizer_history_charge')}:{' '}
+          <span className="font-medium text-foreground">
+            {event.chargeAmount != null
+              ? `¥${event.chargeAmount.toLocaleString()}`
+              : '—'}
+          </span>
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {t('organizer_history_sales')}:{' '}
+          <span className="font-medium text-foreground">
+            {salesAmount != null ? `¥${salesAmount.toLocaleString()}` : '—'}
+          </span>
+        </span>
       </div>
     </li>
   );

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { events, eventParticipations, organizations, barHostPermissions, barBlocks } from "@e-be/db/schema";
-import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray, count } from "drizzle-orm";
+import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray, count, sql } from "drizzle-orm";
 
 /**
  * イベント作成フォームのバー選択用に公開バー一覧を取得する。
@@ -225,6 +225,8 @@ export type OrganizerHistoryItem = {
   orgId: string;
   orgName: string;
   isPublic: boolean;
+  chargeAmount: number | null;
+  participantCount: number;
 };
 
 /**
@@ -236,6 +238,17 @@ export type OrganizerHistoryItem = {
 export async function getOrganizerHistory(userId: string): Promise<OrganizerHistoryItem[]> {
   const now = new Date();
 
+  const participantCountSq = db
+    .select({ count: count() })
+    .from(eventParticipations)
+    .where(
+      and(
+        eq(eventParticipations.eventId, events.id),
+        eq(eventParticipations.status, "registered"),
+        isNull(eventParticipations.deletedAt)
+      )
+    );
+
   const rows = await db
     .select({
       id: events.id,
@@ -246,6 +259,8 @@ export async function getOrganizerHistory(userId: string): Promise<OrganizerHist
       orgId: events.orgId,
       orgName: organizations.name,
       isPublic: events.isPublic,
+      chargeAmount: events.chargeAmount,
+      participantCount: sql<number>`(${participantCountSq})`,
     })
     .from(events)
     .innerJoin(organizations, eq(events.orgId, organizations.id))
@@ -273,6 +288,8 @@ export async function getOrganizerHistory(userId: string): Promise<OrganizerHist
     orgId: row.orgId,
     orgName: row.orgName,
     isPublic: row.isPublic,
+    chargeAmount: row.chargeAmount,
+    participantCount: Number(row.participantCount),
   }));
 }
 


### PR DESCRIPTION
## 概要

ダッシュボードの主催イベント履歴に、各イベントの参加者数・チャージ料・売上金額を表示するカラムを追加しました。

## 変更内容

- `getOrganizerHistory` に `chargeAmount`（イベントのチャージ料）と `participantCount`（`registered` 状態の参加者数サブクエリ）を追加
- `OrganizerHistoryItem` コンポーネントに参加者数・チャージ料・売上金額（chargeAmount × participantCount）を表示
- `chargeAmount` が未設定の場合は `—` 表示
- ja/en 翻訳キーを追加（`organizer_history_participants` / `organizer_history_charge` / `organizer_history_sales`）

## 関連 Issue

Closes #86

## 確認方法

- [ ] テストユーザー（`test-user@e-be.internal`）でログイン
- [ ] ダッシュボードの「主催イベント履歴」に参加者数・チャージ料・売上が表示される
- [ ] チャージ料未設定のイベントは売上が `—` 表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)