### PR TITLE
perf: CSV エクスポートの参加者数クエリに eventId フィルタを追加

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/organizer-history/csv/route.ts
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history/csv/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getUser, getDbUser } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { events, organizations, eventParticipations } from '@e-be/db/schema';
-import { eq, and, isNull, or, lt, count } from 'drizzle-orm';
+import { eq, and, isNull, or, lt, count, inArray } from 'drizzle-orm';
 
 export async function GET() {
   const [, dbUser] = await Promise.all([getUser(), getDbUser()]);
@@ -48,6 +48,7 @@ export async function GET() {
       .from(eventParticipations)
       .where(
         and(
+          inArray(eventParticipations.eventId, eventIds),
           eq(eventParticipations.status, 'registered'),
           isNull(eventParticipations.deletedAt)
         )


### PR DESCRIPTION
## 概要

主催履歴 CSV エクスポートの参加者数取得クエリが全イベントの参加レコードをスキャンしていた問題を修正。対象イベントの ID で絞り込むことでパフォーマンスを改善した。

## 変更内容

- `inArray` を drizzle-orm からインポートに追加
- `eventParticipations` の WHERE 句に `inArray(eventParticipations.eventId, eventIds)` を追加
- 対象イベントのみをスキャンするようになり、参加レコード増加によるパフォーマンス劣化を防ぐ

## 関連 Issue

Closes #84

## 確認方法

- [ ] イベンターアカウントでログインし、主催履歴ページ (`/dashboard/organizer-history`) を開く
- [ ] CSV ダウンロードボタンをクリックし、正常にダウンロードされることを確認
- [ ] CSVの参加者数が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)