### PR TITLE
feat: イベント編集フォームに会場セレクトボックスを追加

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -262,6 +262,7 @@
     "field_start_at": "Start Date & Time",
     "field_end_at": "End Date & Time",
     "field_venue": "Venue",
+    "field_venue_placeholder": "Select a bar",
     "field_max_participants": "Capacity",
     "field_charge_amount": "Cover Charge",
     "field_charge_amount_placeholder": "Leave blank to hide (e.g. 0 for free)",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -262,6 +262,7 @@
     "field_start_at": "開催開始日時",
     "field_end_at": "開催終了日時",
     "field_venue": "会場",
+    "field_venue_placeholder": "バーを選択してください",
     "field_max_participants": "定員",
     "field_charge_amount": "チャージ料",
     "field_charge_amount_placeholder": "未入力の場合は非公開（例: 0 で無料）",

--- a/apps/web/scripts/seed-test-accounts.mjs
+++ b/apps/web/scripts/seed-test-accounts.mjs
@@ -295,6 +295,26 @@ async function main() {
         SELECT id FROM organizations WHERE slug = ${account.org.slug} AND deleted_at IS NULL LIMIT 1
       `;
       testOrgId = row?.id ?? null;
+
+      // セレクトボックス検証用に2件目のバーを作成（冪等）
+      const companyRow = await sql`
+        SELECT id FROM companies WHERE slug = ${account.company.slug} AND deleted_at IS NULL LIMIT 1
+      `;
+      if (companyRow[0]) {
+        const companyId = companyRow[0].id;
+        const [existingBar2] = await sql`
+          SELECT id FROM organizations WHERE slug = 'test-bar-2' AND deleted_at IS NULL LIMIT 1
+        `;
+        if (!existingBar2) {
+          await sql`
+            INSERT INTO organizations (company_id, name, slug, description)
+            VALUES (${companyId}, 'テストバー2', 'test-bar-2', '検証用の2件目テストバーです')
+          `;
+          console.log('  ✅ organization: テストバー2 を作成しました');
+        } else {
+          console.log('  ⏭  organization: test-bar-2 は既に存在します');
+        }
+      }
     }
 
     console.log();

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -10,6 +10,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Select } from "@/components/ui/select";
 import { updateEventDraft, submitEvent, publishEvent } from "@/lib/actions/event";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -19,6 +20,7 @@ type EventData = {
   id: string;
   orgId: string;
   orgName: string;
+  status: string;
   title: string | null;
   description: string | null;
   startAt: string | null;
@@ -32,16 +34,20 @@ type Props = {
   eventId: string;
   hasPermission: boolean;
   locale: string;
+  bars: { id: string; name: string }[];
 };
 
-export function EventEditForm({ event, eventId, hasPermission, locale }: Props) {
+export function EventEditForm({ event, eventId, hasPermission, locale, bars }: Props) {
   const t = useTranslations("event_edit");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [startAt, setStartAt] = useState(event.startAt ?? "");
   const [endAt, setEndAt] = useState(event.endAt ?? "");
+  const [orgId, setOrgId] = useState(event.orgId);
   const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const isDraft = event.status === "draft";
 
   function handleStartAtChange(value: string) {
     setStartAt(value);
@@ -51,16 +57,19 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
     }
   }
 
-  const hasVenue = Boolean(event.orgId);
+  const hasVenue = Boolean(orgId);
   const hasDatetime = startAt !== "" && endAt !== "";
   const isDatetimeInvalid =
     hasDatetime && new Date(startAt) >= new Date(endAt);
   const canSubmit = hasVenue && !isDatetimeInvalid;
   const canPublish = hasVenue && hasDatetime && !isDatetimeInvalid;
 
+  const selectedBar = bars.find((b) => b.id === orgId);
+
   function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
+    formData.set("orgId", orgId);
     setError(null);
 
     startTransition(async () => {
@@ -108,7 +117,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
     <span className="flex flex-col gap-1 text-sm">
       <span className="flex gap-2">
         <span className="text-muted-foreground shrink-0">{t("submit_confirm_venue")}:</span>
-        <span>{event.orgName}</span>
+        <span>{selectedBar?.name ?? event.orgName}</span>
       </span>
       <span className="flex gap-2">
         <span className="text-muted-foreground shrink-0">{t("submit_confirm_datetime")}:</span>
@@ -124,12 +133,27 @@ export function EventEditForm({ event, eventId, hasPermission, locale }: Props) 
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSave} className="space-y-4">
-          {/* 会場（読み取り専用） */}
+          {/* 会場 */}
           <div className="space-y-1">
             <Label>{t("field_venue")}</Label>
-            <p className="rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
-              {event.orgName}
-            </p>
+            {isDraft ? (
+              <Select
+                value={orgId}
+                onChange={(e) => setOrgId(e.target.value)}
+                disabled={isPending}
+              >
+                <option value="" disabled>{t("field_venue_placeholder")}</option>
+                {bars.map((bar) => (
+                  <option key={bar.id} value={bar.id}>
+                    {bar.name}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <p className="rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                {event.orgName}
+              </p>
+            )}
           </div>
 
           <div className="space-y-1">

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getDbUser } from "@/lib/auth";
-import { getDraftEventForOwner, hasBarHostPermission } from "@/lib/events";
+import { getDraftEventForOwner, hasBarHostPermission, getPublicBars } from "@/lib/events";
 import { EventEditForm } from "./event-edit-form";
 
 type Props = {
@@ -19,17 +19,18 @@ export default async function EventEditPage({ params }: Props) {
   // draft のみ編集可能。pending 以降は 404
   if (event.status !== "draft") notFound();
 
-  const [locale, t, hasPermission] = await Promise.all([
+  const [locale, t, hasPermission, bars] = await Promise.all([
     getLocale(),
     getTranslations("event_edit"),
     hasBarHostPermission(dbUser.id, event.orgId),
+    getPublicBars(),
   ]);
 
   return (
     <main className="p-4 md:p-6">
       <div className="mx-auto max-w-lg space-y-4">
         <h1 className="text-2xl font-bold">{t("title")}</h1>
-        <EventEditForm event={event} hasPermission={hasPermission} locale={locale} eventId={eventId} />
+        <EventEditForm event={event} hasPermission={hasPermission} locale={locale} eventId={eventId} bars={bars} />
       </div>
     </main>
   );

--- a/apps/web/src/lib/actions/event.ts
+++ b/apps/web/src/lib/actions/event.ts
@@ -62,9 +62,12 @@ export async function updateEventDraft(eventId: string, formData: FormData): Pro
   const endAtRaw = formData.get('endAt') as string | null;
   const maxParticipantsRaw = formData.get('maxParticipants') as string | null;
   const chargeAmountRaw = formData.get('chargeAmount') as string | null;
+  const orgIdRaw = (formData.get('orgId') as string | null)?.trim() ?? '';
 
   if (!title || title.length > 100) return { error: 'invalid' };
   if (!description || description.length > 2000) return { error: 'invalid' };
+
+  const orgId = orgIdRaw && /^[0-9a-f-]{36}$/.test(orgIdRaw) ? orgIdRaw : undefined;
 
   let maxParticipants: number | null = null;
   if (maxParticipantsRaw && maxParticipantsRaw !== '') {
@@ -95,7 +98,7 @@ export async function updateEventDraft(eventId: string, formData: FormData): Pro
 
   await db
     .update(events)
-    .set({ title, description, startAt, endAt, maxParticipants, chargeAmount, updatedAt: new Date() })
+    .set({ title, description, startAt, endAt, maxParticipants, chargeAmount, ...(orgId ? { orgId } : {}), updatedAt: new Date() })
     .where(eq(events.id, eventId));
 
   return { ok: true };


### PR DESCRIPTION
## 概要

draft 状態のイベント編集フォームで会場（バー）をセレクトボックスで変更できるようにした。また、セレクトボックスの動作確認用にシードスクリプトへ2件目のテストバーを追加した。

## 変更内容

- `updateEventDraft` に `orgId` の読み取り・UUID バリデーション・DB 更新を追加
- `page.tsx` で `getPublicBars()` を呼び出し `bars` prop をフォームに渡す
- `event-edit-form.tsx`: `draft` 状態のみネイティブ `<select>` で会場選択可能に、`pending` 以降は読み取り専用テキスト表示を維持
- `seed-test-accounts.mjs`: セレクトボックス検証用にテストバー2（`test-bar-2`）を冪等に追加
- `ja.json` / `en.json`: `field_venue_placeholder` 翻訳キーを追加

## 関連 Issue

Closes #90

## 確認方法

- [ ] `test-user@e-be.internal` でログインし、ダッシュボードからドラフトイベントの編集ページを開く
- [ ] 会場フィールドがセレクトボックスになっており、バー一覧が表示されることを確認
- [ ] 別のバーを選択して「下書き保存」をクリックし、保存後も選択が反映されることを確認
- [ ] `pnpm seed:test` を実行してテストバーが2件以上作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)