### PR TITLE
chore: Dialog の showCloseButton テキストを i18n 対応する

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3,6 +3,9 @@
     "confirmDialog": {
       "confirm": "Confirm",
       "cancel": "Cancel"
+    },
+    "dialog": {
+      "close": "Close"
     }
   },
   "home": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3,6 +3,9 @@
     "confirmDialog": {
       "confirm": "確認",
       "cancel": "キャンセル"
+    },
+    "dialog": {
+      "close": "閉じる"
     }
   },
   "home": {

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -43,9 +43,11 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  closeSrLabel,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  closeSrLabel?: string
 }) {
   return (
     <DialogPortal>
@@ -72,7 +74,7 @@ function DialogContent({
           >
             <XIcon
             />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{closeSrLabel ?? "Close"}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
@@ -93,10 +95,12 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 function DialogFooter({
   className,
   showCloseButton = false,
+  closeLabel,
   children,
   ...props
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean
+  closeLabel?: string
 }) {
   return (
     <div
@@ -108,9 +112,9 @@ function DialogFooter({
       {...props}
     >
       {children}
-      {showCloseButton && (
+      {showCloseButton && closeLabel && (
         <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
+          {closeLabel}
         </DialogPrimitive.Close>
       )}
     </div>


### PR DESCRIPTION
## 概要

`dialog.tsx` の `DialogFooter` と `DialogContent` にハードコードされていた "Close" テキストを i18n 対応しました。

## 変更内容

- `DialogContent` に `closeSrLabel?: string` prop を追加（閉じるボタンの `sr-only` テキストを呼び出し元から渡せるように）
- `DialogFooter` に `closeLabel?: string` prop を追加（`showCloseButton={true}` 時のラベルを呼び出し元から渡せるように）
- `common.dialog.close` 翻訳キーを `ja.json` / `en.json` に追加

## 関連 Issue

Closes #94

## 確認方法

- [ ] `showCloseButton` の既存使用箇所（`confirm-dialog.tsx` の `showCloseButton={false}`）に影響がないこと
- [ ] TypeScript 型エラーがないこと（`npx tsc --noEmit` → exit 0 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)