### PR TITLE
test: イベント関連 Server Actions のユニットテストを追加

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -37,6 +39,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/web/src/lib/actions/__tests__/event.test.ts
+++ b/apps/web/src/lib/actions/__tests__/event.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// モック設定
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getDbUser: vi.fn(),
+  getUser: vi.fn(),
+  getUserType: vi.fn(),
+}));
+
+vi.mock('@/lib/events', () => ({
+  checkEventConflict: vi.fn(),
+  hasBarHostPermission: vi.fn(),
+}));
+
+vi.mock('@/lib/notify', () => ({
+  sendNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@e-be/db', () => ({
+  NOTIFICATION_TYPES: {
+    PARTICIPATION_RECEIVED: 'participation_received',
+  },
+}));
+
+import { db } from '@/lib/db';
+import { getDbUser } from '@/lib/auth';
+import { updateEventDraft, submitEvent, publishEvent } from '../event';
+
+// Drizzle クエリチェーンを組み立てるヘルパー
+function makeSelectChain(resolvedValue: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(resolvedValue);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from, where, limit };
+}
+
+function makeUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  return { set, where };
+}
+
+// テスト用のユーザーIDとイベントID
+const USER_A = 'user-aaaa-0000-0000-000000000001';
+const USER_B = 'user-bbbb-0000-0000-000000000002';
+const EVENT_OWNED_BY_B = 'event-bbbb-0000-0000-000000000001';
+
+describe('イベント管理 Server Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ====================================================
+  // テスト 1: 他人のイベントを管理できないこと
+  // ====================================================
+  describe('updateEventDraft — 他人のイベントを変更できないこと', () => {
+    it('userA が userB のイベントを更新しようとすると not_found を返す', async () => {
+      // userA としてログイン
+      vi.mocked(getDbUser).mockResolvedValue({ id: USER_A } as never);
+
+      // db.select で空配列を返す（userId が一致しないためレコードなし）
+      const chain = makeSelectChain([]);
+      vi.mocked(db.select).mockReturnValue({ from: chain.from } as never);
+
+      const formData = new FormData();
+      formData.set('title', '悪意のある更新');
+      formData.set('description', '他人のイベントを乗っ取ろうとしている');
+
+      const result = await updateEventDraft(EVENT_OWNED_BY_B, formData);
+
+      expect(result).toEqual({ error: 'not_found' });
+      // DB更新が呼ばれていないことを確認
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submitEvent — 他人のイベントを申請できないこと', () => {
+    it('userA が userB のイベントを申請しようとすると not_found を返す', async () => {
+      vi.mocked(getDbUser).mockResolvedValue({ id: USER_A } as never);
+
+      const chain = makeSelectChain([]);
+      vi.mocked(db.select).mockReturnValue({ from: chain.from } as never);
+
+      const result = await submitEvent(EVENT_OWNED_BY_B);
+
+      expect(result).toEqual({ error: 'not_found' });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('publishEvent — 他人のイベントを公開できないこと', () => {
+    it('userA が userB のイベントを公開しようとすると not_found を返す', async () => {
+      vi.mocked(getDbUser).mockResolvedValue({ id: USER_A } as never);
+
+      const chain = makeSelectChain([]);
+      vi.mocked(db.select).mockReturnValue({ from: chain.from } as never);
+
+      const result = await publishEvent(EVENT_OWNED_BY_B);
+
+      expect(result).toEqual({ error: 'not_found' });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ====================================================
+  // テスト 2: 自分がイベントを主催していても別イベントに参加できること
+  //
+  // joinEvent は event.userId !== dbUser.id チェックを行わない設計。
+  // イベント主催者 (userA) が別の published イベントに参加できることを確認する。
+  // ====================================================
+  describe('認可の境界確認: updateEventDraft は自分のイベントなら更新できること', () => {
+    it('userA が自分のイベントを更新するとき ok を返す', async () => {
+      const MY_EVENT = 'event-aaaa-0000-0000-000000000001';
+
+      vi.mocked(getDbUser).mockResolvedValue({ id: USER_A } as never);
+
+      // select で自分のイベントを返す（status: draft）
+      const selectChain = makeSelectChain([{ id: MY_EVENT, status: 'draft' }]);
+      vi.mocked(db.select).mockReturnValue({ from: selectChain.from } as never);
+
+      // update チェーン
+      const updateChain = makeUpdateChain();
+      vi.mocked(db.update).mockReturnValue({ set: updateChain.set } as never);
+
+      const formData = new FormData();
+      formData.set('title', '正しいタイトル');
+      formData.set('description', '正しい説明文です');
+
+      const result = await updateEventDraft(MY_EVENT, formData);
+
+      expect(result).toEqual({ ok: true });
+      expect(db.update).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/participation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/participation.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getDbUser: vi.fn(),
+  getUser: vi.fn(),
+}));
+
+vi.mock('@/lib/notify', () => ({
+  sendNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@e-be/db', () => ({
+  NOTIFICATION_TYPES: {
+    PARTICIPATION_RECEIVED: 'participation_received',
+  },
+}));
+
+import { db } from '@/lib/db';
+import { getDbUser } from '@/lib/auth';
+import { joinEvent } from '../participation';
+
+// Drizzle クエリチェーンヘルパー
+function makeSelectChain(resolvedValue: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(resolvedValue);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  return { from, where, limit };
+}
+
+function makeSelectWithCountChain(total: number) {
+  const where = vi.fn().mockResolvedValue([{ total }]);
+  const from = vi.fn().mockReturnValue({ where });
+  return { from, where };
+}
+
+// テスト用 ID
+const USER_ORGANIZER = 'user-organizer-000-000000000001'; // イベントを主催しているユーザー
+const USER_EVENT_OWNER = 'user-owner-0000-000000000002'; // 参加対象イベントの主催者
+const OTHER_EVENT_ID = 'event-other-0000-000000000001'; // 別の公開イベント
+
+describe('joinEvent — イベント参加申請', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * テスト: 自身がイベントを主催していても、別の公開イベントに参加できること
+   *
+   * joinEvent の WHERE 条件は:
+   *   - events.status = 'published'
+   *   - events.deleted_at IS NULL
+   * であり、events.userId ≠ dbUser.id のチェックはない。
+   * つまり、イベント主催者であるかどうかに関係なく参加申請できる。
+   */
+  it('自身がイベント主催者でも、別の公開イベントに参加申請できること', async () => {
+    // USER_ORGANIZER としてログイン（自分自身も別イベントを主催している）
+    vi.mocked(getDbUser).mockResolvedValue({ id: USER_ORGANIZER } as never);
+
+    // 1回目の select: published イベントを返す（USER_EVENT_OWNER が主催）
+    const eventChain = makeSelectChain([
+      {
+        id: OTHER_EVENT_ID,
+        userId: USER_EVENT_OWNER, // 別ユーザーが主催（organizer ではない）
+        startAt: new Date(Date.now() + 86400000), // 24時間後
+        maxParticipants: null, // 定員なし
+      },
+    ]);
+
+    // 2回目の select: 既存の参加レコードなし
+    const existingChain = makeSelectChain([]);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: eventChain.from } as never)
+      .mockReturnValueOnce({ from: existingChain.from } as never);
+
+    // insert: 参加レコードを挿入
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const result = await joinEvent(OTHER_EVENT_ID);
+
+    // 参加申請が成功すること
+    expect(result).toEqual({ ok: true });
+
+    // 参加レコードが挿入されたこと
+    expect(db.insert).toHaveBeenCalledOnce();
+  });
+
+  it('既に参加済みのイベントに再度申請すると already_registered を返す', async () => {
+    vi.mocked(getDbUser).mockResolvedValue({ id: USER_ORGANIZER } as never);
+
+    const eventChain = makeSelectChain([
+      {
+        id: OTHER_EVENT_ID,
+        userId: USER_EVENT_OWNER,
+        startAt: new Date(Date.now() + 86400000),
+        maxParticipants: null,
+      },
+    ]);
+
+    // 既存の参加レコードあり（status: registered）
+    const existingChain = makeSelectChain([
+      { id: 'participation-001', status: 'registered' },
+    ]);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: eventChain.from } as never)
+      .mockReturnValueOnce({ from: existingChain.from } as never);
+
+    const result = await joinEvent(OTHER_EVENT_ID);
+
+    expect(result).toEqual({ error: 'already_registered' });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('定員が満員のイベントには参加申請できない', async () => {
+    vi.mocked(getDbUser).mockResolvedValue({ id: USER_ORGANIZER } as never);
+
+    const eventChain = makeSelectChain([
+      {
+        id: OTHER_EVENT_ID,
+        userId: USER_EVENT_OWNER,
+        startAt: new Date(Date.now() + 86400000),
+        maxParticipants: 10, // 定員10名
+      },
+    ]);
+
+    // 既存の参加レコードなし
+    const existingChain = makeSelectChain([]);
+
+    // 定員カウント（10名 = 定員に達している）
+    const countChain = makeSelectWithCountChain(10);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: eventChain.from } as never)
+      .mockReturnValueOnce({ from: existingChain.from } as never)
+      .mockReturnValueOnce({ from: countChain.from } as never);
+
+    const result = await joinEvent(OTHER_EVENT_ID);
+
+    expect(result).toEqual({ error: 'full_capacity' });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('未認証ユーザーは参加申請できない', async () => {
+    vi.mocked(getDbUser).mockResolvedValue(null);
+
+    const result = await joinEvent(OTHER_EVENT_ID);
+
+    expect(result).toEqual({ error: 'unauthorized' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0))
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.37)(lightningcss@1.32.0)(msw@2.12.13(@types/node@20.19.37)(typescript@5.9.3))
 
   docs:
     devDependencies:
@@ -3175,6 +3181,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4531,6 +4540,16 @@ packages:
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4690,6 +4709,11 @@ packages:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@6.1.1:
+    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
+    peerDependencies:
+      vite: '*'
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -7802,6 +7826,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9231,6 +9257,10 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -9467,6 +9497,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+      vite: 5.4.21(@types/node@20.19.37)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.4.21(@types/node@20.19.37)(lightningcss@1.32.0):
     dependencies:


### PR DESCRIPTION
## 概要

vitest を導入し、イベント管理の Server Actions に対するユニットテストを追加した。
「他人のイベントを管理できないこと」と「自身がイベントを主催していても別イベントに参加できること」をテストで保証する。

## 変更内容

- vitest + vite-tsconfig-paths をセットアップ（`vitest.config.mts`, `package.json` に `test` スクリプト追加）
- `event.test.ts`: 他人のイベントに対して `updateEventDraft` / `submitEvent` / `publishEvent` が `not_found` を返すことをテスト
- `participation.test.ts`: イベント主催者でも `joinEvent` で別の公開イベントに参加できることをテスト（+ 参加済み・定員超過・未認証ケース）
- 8テスト全グリーン (`pnpm test` で確認済み)

## 関連 Issue

Closes #65

## 確認方法

- [ ] `cd apps/web && pnpm test` を実行し 8 テストがすべてグリーンになることを確認
- [ ] `pnpm test:watch` でウォッチモードが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)