### PR TITLE
fix: 申請確認モーダルの日時表示を ISO 文字列から自然な表現に修正する (#103)

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -37,6 +37,37 @@ type Props = {
   bars: { id: string; name: string }[];
 };
 
+function formatDatetimeRange(startIso: string, endIso: string, locale: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+
+  const dateOpts: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  };
+  const timeOpts: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+  };
+
+  const startDateStr = start.toLocaleDateString(locale, dateOpts);
+  const startTimeStr = start.toLocaleTimeString(locale, timeOpts);
+  const endTimeStr = end.toLocaleTimeString(locale, timeOpts);
+
+  const isSameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  if (isSameDay) {
+    return `${startDateStr} ${startTimeStr} 〜 ${endTimeStr}`;
+  }
+  const endDateStr = end.toLocaleDateString(locale, dateOpts);
+  return `${startDateStr} ${startTimeStr} 〜 ${endDateStr} ${endTimeStr}`;
+}
+
 export function EventEditForm({ event, eventId, hasPermission, locale, bars }: Props) {
   const t = useTranslations("event_edit");
   const router = useRouter();
@@ -121,7 +152,11 @@ export function EventEditForm({ event, eventId, hasPermission, locale, bars }: P
       </span>
       <span className="flex gap-2">
         <span className="text-muted-foreground shrink-0">{t("submit_confirm_datetime")}:</span>
-        <span>{hasDatetime ? `${startAt} 〜 ${endAt}` : t("submit_confirm_not_set")}</span>
+        <span>
+          {hasDatetime
+            ? formatDatetimeRange(startAt, endAt, locale)
+            : t("submit_confirm_not_set")}
+        </span>
       </span>
     </span>
   );


### PR DESCRIPTION
## Summary

- `申請内容の確認` モーダルで日時が `2026-02-28T15:00:00.000Z 〜 ...` という ISO 8601 形式のまま表示されていたバグを修正
- `formatDatetimeRange()` ヘルパーを追加し、`Intl.DateTimeFormat` でロケール対応のフォーマットに変換
- 同日の場合: `2026年3月13日(金) 00:00 〜 16:00`（日付は1回のみ）
- 日をまたぐ場合: `2026年3月13日(金) 00:00 〜 2026年3月14日(土) 15:00`

## Test plan

- [x] モーダルの日時が自然な表現で表示されることを Playwright で確認
- [x] 同日・日またぎの両パターンをコードレビューで確認
- [x] `ja` ロケールで正しくフォーマットされることを確認

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)