### PR TITLE
design: デザイントークンに Amber・Violet の 2 色を追加する (#104)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -13,6 +13,10 @@
   --color-brand-foreground: var(--brand-foreground);
   --color-feature: var(--feature);
   --color-feature-foreground: var(--feature-foreground);
+  --color-amber: var(--amber);
+  --color-amber-foreground: var(--amber-foreground);
+  --color-violet: var(--violet);
+  --color-violet-foreground: var(--violet-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -79,6 +83,10 @@
   --brand-foreground: oklch(0.2 0.05 70);
   --feature: oklch(0.606 0.213 293.74);
   --feature-foreground: oklch(0.985 0 0);
+  --amber: oklch(0.769 0.188 70.08);
+  --amber-foreground: oklch(0.2 0.05 70);
+  --violet: oklch(0.606 0.213 293.74);
+  --violet-foreground: oklch(0.985 0 0);
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
@@ -118,6 +126,10 @@
   --brand-foreground: oklch(0.15 0.04 68);
   --feature: oklch(0.65 0.22 293);
   --feature-foreground: oklch(0.985 0 0);
+  --amber: oklch(0.75 0.17 68);
+  --amber-foreground: oklch(0.15 0.04 68);
+  --violet: oklch(0.65 0.22 293);
+  --violet-foreground: oklch(0.985 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
## 概要

`globals.css` に `--amber` / `--violet` の CSS 変数とそれに対応する Tailwind v4 トークンを追加しました。
バー・ナイトライフのブランドイメージに合う 2 色をデザインシステムに正式追加します。

## 変更内容

- `@theme inline` に `--color-amber` / `--color-amber-foreground` / `--color-violet` / `--color-violet-foreground` を追加
- `:root` に Amber・Violet のライトモード値を追加（oklch カラー空間）
- `.dark` に Amber・Violet のダークモード値を追加

## 関連 Issue

Closes #104

## 確認方法

- [ ] `bg-amber` / `text-amber-foreground` が Tailwind クラスとして使える
- [ ] `bg-violet` / `text-violet-foreground` が Tailwind クラスとして使える
- [ ] ライト・ダーク双方で視認性が確保されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)