### PR TITLE
design: LP の課題セクション・Features セクションのアドホックカラーを brand/feature トークンに統一

### DIFF
--- a/.claude/steering/issue-105-lp-problem-features-amber-violet.md
+++ b/.claude/steering/issue-105-lp-problem-features-amber-violet.md
@@ -1,0 +1,72 @@
+# Issue #105: design: LP の課題セクション・Features セクションのアドホックカラーを amber/violet トークンに統一
+
+## 背景
+
+LP ページ（`apps/web/src/app/[locale]/page.tsx`）の Pain セクションと Features セクションで
+`blue-500` / `indigo-500` / `orange-500` 等の Tailwind アドホックカラーが散在している。
+`--brand`（琥珀） / `--feature`（紫） デザイントークンを活用し、配色をブランドイメージに合わせつつ整理する。
+
+## 参照
+
+- GitHub Issue: #105
+- 関連ドキュメント: なし
+- 既存実装: `apps/web/src/app/[locale]/page.tsx`
+- デザイントークン定義: `apps/web/src/app/globals.css`
+
+## 実装方針
+
+以下のマッピングに従って色を置き換える。
+
+| ユーザー区分 | 現在の色 (Tailwind) | 変更後のトークン | 補足 |
+|------------|-------------------|----------------|------|
+| バーオーナー (Venue) | `blue-500` / `blue-700` / `blue-50` | `feature` 系 (紫) | 既存の `--feature` を使用 |
+| イベンター (Eventer) | `indigo-500` / `indigo-700` / `indigo-50` | `feature` 系 (紫) | 濃淡が必要な場合は opacity 等で調整 |
+| 参加者 (Participant) | `orange-500` / `orange-700` / `orange-50` | `brand` 系 (琥珀) | 既存の `--brand` を使用 |
+
+※ `globals.css` にて `--brand` と `--amber`、`--feature` と `--violet` は同じ値が割り当てられているが、Issue 本文の指示に従い `brand` / `feature` トークンを優先的に使用する。
+
+## 実装ステップ
+
+### 1. Pain セクションの修正 (`apps/web/src/app/[locale]/page.tsx`)
+
+- **バーオーナー (Venue)**:
+  - `border-t-blue-500` -> `border-t-feature`
+  - `text-blue-700` -> `text-feature`
+  - `text-blue-500` (アイコン) -> `text-feature`
+- **イベンター (Eventer)**:
+  - `border-t-indigo-500` -> `border-t-feature`
+  - `text-indigo-700` -> `text-feature`
+  - `text-indigo-500` (アイコン) -> `text-feature`
+- **参加者 (Participant)**:
+  - `border-t-orange-500` -> `border-t-brand`
+  - `text-orange-700` -> `text-brand`
+  - `text-orange-500` (アイコン) -> `text-brand`
+
+### 2. Features セクションの修正 (`apps/web/src/app/[locale]/page.tsx`)
+
+- **店舗管理者向け (Venue)**:
+  - `bg-blue-50/50` -> `bg-feature/5` (または適切な薄い色)
+  - `ring-blue-100` -> `ring-feature/20`
+  - `text-blue-900` -> `text-feature`
+  - `bg-blue-600` -> `bg-feature`
+- **イベント主催者向け (Eventer)**:
+  - `bg-indigo-50/50` -> `bg-feature/5`
+  - `ring-indigo-100` -> `ring-feature/20`
+  - `text-indigo-900` -> `text-feature`
+  - `bg-indigo-600` -> `bg-feature`
+- **イベント参加者向け (Participant)**:
+  - `bg-orange-50/50` -> `bg-brand/5`
+  - `ring-orange-100` -> `ring-brand/20`
+  - `text-orange-900` -> `text-brand`
+  - `bg-orange-600` -> `bg-brand`
+
+## 影響範囲
+
+- `apps/web/src/app/[locale]/page.tsx` の表示配色のみ
+
+## チェックリスト
+
+- [ ] Pain セクションの 3 つのカードの色が `feature` / `brand` トークンに置き換わっている
+- [ ] Features セクションの 3 つのブロックの背景・見出し・番号の色が `feature` / `brand` トークンに置き換わっている
+- [ ] ダークモードで色が沈みすぎたり、コントラスト不足になったりしていないことを確認
+- [ ] Tailwind の `blue-500` 等のアドホックカラーが該当箇所から一掃されている

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -113,9 +113,9 @@ export default async function HomePage() {
           </h2>
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
             {/* バーオーナー */}
-            <Card className="border-t-4 border-t-blue-500">
+            <Card className="border-t-4 border-t-feature">
               <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-base text-blue-700">
+                <CardTitle className="flex items-center gap-2 text-base text-feature">
                   <span className="text-2xl">🏪</span>
                   {t("pain.venue_label")}
                 </CardTitle>
@@ -124,7 +124,7 @@ export default async function HomePage() {
                 <ul className="space-y-3">
                   {venueItemKeys.map((key) => (
                     <li key={key} className="flex items-start gap-2 text-sm text-muted-foreground">
-                      <span className="mt-0.5 shrink-0 text-blue-500">✕</span>
+                      <span className="mt-0.5 shrink-0 text-feature">✕</span>
                       {t(key)}
                     </li>
                   ))}
@@ -133,9 +133,9 @@ export default async function HomePage() {
             </Card>
 
             {/* イベンター */}
-            <Card className="border-t-4 border-t-indigo-500">
+            <Card className="border-t-4 border-t-feature">
               <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-base text-indigo-700">
+                <CardTitle className="flex items-center gap-2 text-base text-feature">
                   <span className="text-2xl">🎤</span>
                   {t("pain.eventer_label")}
                 </CardTitle>
@@ -144,7 +144,7 @@ export default async function HomePage() {
                 <ul className="space-y-3">
                   {eventerItemKeys.map((key) => (
                     <li key={key} className="flex items-start gap-2 text-sm text-muted-foreground">
-                      <span className="mt-0.5 shrink-0 text-indigo-500">✕</span>
+                      <span className="mt-0.5 shrink-0 text-feature">✕</span>
                       {t(key)}
                     </li>
                   ))}
@@ -153,9 +153,9 @@ export default async function HomePage() {
             </Card>
 
             {/* 参加者 */}
-            <Card className="border-t-4 border-t-orange-500">
+            <Card className="border-t-4 border-t-brand">
               <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-base text-orange-700">
+                <CardTitle className="flex items-center gap-2 text-base text-brand">
                   <span className="text-2xl">👥</span>
                   {t("pain.participant_label")}
                 </CardTitle>
@@ -164,7 +164,7 @@ export default async function HomePage() {
                 <ul className="space-y-3">
                   {participantItemKeys.map((key) => (
                     <li key={key} className="flex items-start gap-2 text-sm text-muted-foreground">
-                      <span className="mt-0.5 shrink-0 text-orange-500">✕</span>
+                      <span className="mt-0.5 shrink-0 text-brand">✕</span>
                       {t(key)}
                     </li>
                   ))}
@@ -184,9 +184,9 @@ export default async function HomePage() {
 
           <div className="space-y-16">
             {/* 店舗管理者向け */}
-            <div className="rounded-2xl bg-blue-50/50 p-8 ring-1 ring-blue-100">
-              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-blue-900">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600 text-white text-sm">1</span>
+            <div className="rounded-2xl bg-feature/5 p-8 ring-1 ring-feature/20">
+              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-feature">
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-feature text-white text-sm">1</span>
                 {t("features.venue_title")}
               </h3>
               <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -213,9 +213,9 @@ export default async function HomePage() {
             </div>
 
             {/* イベント主催者向け */}
-            <div className="rounded-2xl bg-indigo-50/50 p-8 ring-1 ring-indigo-100">
-              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-indigo-900">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-white text-sm">2</span>
+            <div className="rounded-2xl bg-feature/5 p-8 ring-1 ring-feature/20">
+              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-feature">
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-feature text-white text-sm">2</span>
                 {t("features.eventer_title")}
               </h3>
               <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -242,9 +242,9 @@ export default async function HomePage() {
             </div>
 
             {/* イベント参加者向け */}
-            <div className="rounded-2xl bg-orange-50/50 p-8 ring-1 ring-orange-100">
-              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-orange-900">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-600 text-white text-sm">3</span>
+            <div className="rounded-2xl bg-brand/5 p-8 ring-1 ring-brand/20">
+              <h3 className="mb-8 flex items-center gap-2 text-xl font-bold text-brand">
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand text-white text-sm">3</span>
                 {t("features.participant_title")}
               </h3>
               <div className="grid grid-cols-1 gap-6 md:grid-cols-3">


### PR DESCRIPTION
## 概要
LP ページの Pain セクションと Features セクションで使用されていた Tailwind のアドホックカラー（blue, indigo, orange）を、新しく導入された `brand`（琥珀）および `feature`（紫）デザイントークンに置き換えました。

## 変更内容
- `apps/web/src/app/[locale]/page.tsx`
  - Pain セクションのカード境界、テキスト、アイコン色を `brand` / `feature` に変更
  - Features セクションの背景、リング、見出し、ステップ番号の色を `brand` / `feature` に変更
  - 不透明度（`/5`, `/20`）を活用し、元のデザインのトーンを維持しつつトークン化を実現

## 関連 Issue
Closes #105

## 確認方法
- [ ] LP（/ja）の「課題提起」セクションの配色が整理されていること（バーオーナー・主催者は紫、参加者は琥珀）
- [ ] LP（/ja）の「Features」セクションの 3 つのブロック背景・見出し・番号が、対応する `feature` または `brand` 色になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)