### PR TITLE
design: Hero CTA ボタンと How it works ステップ番号に brand カラーを適用 (#106)

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -285,7 +285,7 @@ export default async function HomePage() {
 
             {howSteps.map(({ titleKey, descKey }, idx) => (
               <div key={titleKey} className="flex flex-col items-center text-center">
-                <div className="relative mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-foreground font-bold text-background text-lg">
+                <div className="relative mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-brand font-bold text-brand-foreground text-lg">
                   {String(idx + 1).padStart(2, "0")}
                 </div>
                 <h3 className="mb-2 font-semibold">{t(titleKey)}</h3>

--- a/apps/web/src/components/lp/link-button.tsx
+++ b/apps/web/src/components/lp/link-button.tsx
@@ -16,7 +16,7 @@ const base =
   "inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent text-sm font-medium whitespace-nowrap transition-all select-none";
 
 const variants: Record<Variant, string> = {
-  default: "bg-primary text-primary-foreground hover:bg-primary/80",
+  default: "bg-brand text-brand-foreground hover:bg-brand/80",
   outline:
     "border-border bg-background hover:bg-muted hover:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
   ghost: "hover:bg-muted hover:text-foreground",


### PR DESCRIPTION
## 概要

LP の Hero セクションのプライマリ CTA ボタンと「使い方」セクションのステップ番号バッジに `--brand` デザイントークンを適用し、バーらしい温かみのあるアクセントを持たせる。

## 変更内容

- `apps/web/src/components/lp/link-button.tsx`: `default` variant を `bg-primary` → `bg-brand text-brand-foreground hover:bg-brand/80` に変更
- `apps/web/src/app/[locale]/page.tsx`: How it works ステップ番号バッジを `bg-foreground text-background` → `bg-brand text-brand-foreground` に変更

## 関連 Issue

Closes #106

## 確認方法

- [ ] LP（`/ja`）を開き、Hero の「はじめる」ボタンが amber 系の暖色になっている
- [ ] 「使い方」セクションのステップ番号バッジ（01/02/03）が amber 系になっている
- [ ] ダークモードでも正しく表示される
- [ ] ダッシュボード内の Button コンポーネントに影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)