### PR TITLE
feat: イベント検索機能を追加する (#82)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -206,7 +206,10 @@
       "x_url_saved": "X URL saved",
       "x_url_error_invalid": "Please enter a URL starting with https://x.com/ or https://twitter.com/",
       "x_url_error_unknown": "Failed to save"
-    }
+    },
+    "upcoming_events_title": "Upcoming Events",
+    "upcoming_events_empty": "No public events available",
+    "upcoming_events_see_more": "See more"
   },
   "apply": {
     "title": "Venue Operator Application",
@@ -389,5 +392,20 @@
         "content": "The Service is not liable for any damages incurred by users regarding the use of the Service, except in cases of intentional misconduct or gross negligence by the Service."
       }
     }
+  },
+  "events": {
+    "title": "Events",
+    "filter_date": "Date",
+    "filter_prefecture": "Prefecture",
+    "filter_line": "Train Line",
+    "filter_search": "Search",
+    "filter_reset": "Reset",
+    "empty": "No events found matching your criteria",
+    "charge_free": "Free",
+    "charge_amount": "¥{amount}",
+    "seats_remaining": "{count} seats left",
+    "seats_full": "Full",
+    "page_prev": "Previous",
+    "page_next": "Next"
   }
 }

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -206,7 +206,10 @@
       "x_url_saved": "X URL を保存しました",
       "x_url_error_invalid": "https://x.com/ または https://twitter.com/ で始まる URL を入力してください",
       "x_url_error_unknown": "保存に失敗しました"
-    }
+    },
+    "upcoming_events_title": "開催予定イベント",
+    "upcoming_events_empty": "公開中のイベントはありません",
+    "upcoming_events_see_more": "もっと見る"
   },
   "apply": {
     "title": "事業者申請",
@@ -389,5 +392,20 @@
         "content": "当サービスは、本サービスに関してユーザーに生じた損害について、当サービスの故意または重過失による場合を除き、一切の責任を負いません。"
       }
     }
+  },
+  "events": {
+    "title": "イベント一覧",
+    "filter_date": "開催日",
+    "filter_prefecture": "都道府県",
+    "filter_line": "路線",
+    "filter_search": "検索",
+    "filter_reset": "リセット",
+    "empty": "条件に合うイベントが見つかりません",
+    "charge_free": "無料",
+    "charge_amount": "¥{amount}",
+    "seats_remaining": "残席{count}",
+    "seats_full": "満席",
+    "page_prev": "前のページ",
+    "page_next": "次のページ"
   }
 }

--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { EventCalendar } from "@/components/event-calendar";
-import { getEventsForCalendar, getMyDraftEvents, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations } from "@/lib/events";
+import { getEventsForCalendar, getMyDraftEvents, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations, searchPublicEvents } from "@/lib/events";
 import { OrganizerHistoryItem } from "./organizer-history-item";
 
 const USER_TYPE_VARIANT = {
@@ -25,10 +25,11 @@ export default async function DashboardPage() {
   const calendarFrom = new Date(now.getFullYear(), now.getMonth(), 1);
   const calendarTo = new Date(now.getFullYear(), now.getMonth() + 3, 0);
 
-  const [userOrgs, userType, calendarEvents] = await Promise.all([
+  const [userOrgs, userType, calendarEvents, upcomingPublicEvents] = await Promise.all([
     getUserOrgs(user.id),
     getUserType(user.id),
     getEventsForCalendar({ from: calendarFrom, to: calendarTo }),
+    searchPublicEvents({ limit: 3 }),
   ]);
 
   // userType === 'user' のみ必要なデータを並行取得
@@ -80,6 +81,51 @@ export default async function DashboardPage() {
                   initialMonth={now.getMonth()}
                   locale={locale}
                 />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>{t("upcoming_events_title")}</CardTitle>
+                  <Link
+                    href={`/${locale}/events`}
+                    className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {t("upcoming_events_see_more")} →
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {upcomingPublicEvents.length === 0 ? (
+                  <p className="py-4 text-center text-sm text-muted-foreground">
+                    {t("upcoming_events_empty")}
+                  </p>
+                ) : (
+                  <ul className="divide-y">
+                    {upcomingPublicEvents.map((event) => (
+                      <li key={event.id}>
+                        <Link
+                          href={`/${locale}/dashboard/event/${event.id}`}
+                          className="flex items-center justify-between gap-3 py-3 -mx-2 px-2 rounded-md transition-colors hover:bg-muted/50"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate font-medium">{event.title ?? "—"}</p>
+                            <p className="text-xs text-muted-foreground">{event.orgName}</p>
+                          </div>
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            {event.startAt
+                              ? new Date(event.startAt).toLocaleDateString(locale, {
+                                  month: "short",
+                                  day: "numeric",
+                                })
+                              : "—"}
+                          </span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </CardContent>
             </Card>
 

--- a/apps/web/src/app/[locale]/events/events-filter.tsx
+++ b/apps/web/src/app/[locale]/events/events-filter.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useRef } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { useTranslations } from "next-intl";
+
+const PREFECTURES = [
+  "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+  "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+  "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県",
+  "静岡県", "愛知県", "三重県", "滋賀県", "京都府", "大阪府", "兵庫県",
+  "奈良県", "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+  "徳島県", "香川県", "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県",
+  "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県",
+];
+
+type Props = {
+  defaultDate?: string;
+  defaultPrefecture?: string;
+  defaultLine?: string;
+};
+
+export function EventsFilter({ defaultDate, defaultPrefecture, defaultLine }: Props) {
+  const t = useTranslations("events");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const dateRef = useRef<HTMLInputElement>(null);
+  const lineRef = useRef<HTMLInputElement>(null);
+  const prefectureRef = useRef<HTMLSelectElement>(null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    const date = dateRef.current?.value;
+    const line = lineRef.current?.value;
+    const prefecture = prefectureRef.current?.value;
+    if (date) params.set("date", date);
+    if (prefecture) params.set("prefecture", prefecture);
+    if (line) params.set("line", line);
+    router.push(`?${params.toString()}`);
+  }
+
+  function handleReset() {
+    router.push("?");
+  }
+
+  const hasFilters = searchParams.get("date") || searchParams.get("prefecture") || searchParams.get("line");
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t("filter_date")}</label>
+        <Input
+          ref={dateRef}
+          type="date"
+          defaultValue={defaultDate}
+          className="w-full sm:w-44"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t("filter_prefecture")}</label>
+        <Select
+          ref={prefectureRef}
+          defaultValue={defaultPrefecture ?? ""}
+          className="w-full sm:w-40"
+        >
+          <option value="">—</option>
+          {PREFECTURES.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t("filter_line")}</label>
+        <Input
+          ref={lineRef}
+          type="text"
+          placeholder="例: 山手線"
+          defaultValue={defaultLine}
+          className="w-full sm:w-44"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <Button type="submit">{t("filter_search")}</Button>
+        {hasFilters && (
+          <Button type="button" variant="outline" onClick={handleReset}>
+            {t("filter_reset")}
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -1,0 +1,141 @@
+import { getLocale, getTranslations } from "next-intl/server";
+import Link from "next/link";
+import { searchPublicEvents } from "@/lib/events";
+import { EventsFilter } from "./events-filter";
+import { AppFooter } from "@/components/layout/app-footer";
+
+const PAGE_SIZE = 20;
+
+type SearchParams = Promise<{
+  date?: string;
+  prefecture?: string;
+  line?: string;
+  page?: string;
+}>;
+
+export default async function EventsPage({ searchParams }: { searchParams: SearchParams }) {
+  const { date, prefecture, line, page } = await searchParams;
+  const locale = await getLocale();
+  const t = await getTranslations("events");
+
+  const currentPage = Math.max(1, Number(page ?? 1));
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  // 1件多く取得してページ送りの有無を判断する
+  const items = await searchPublicEvents({
+    date,
+    prefecture,
+    line,
+    limit: PAGE_SIZE + 1,
+    offset,
+  });
+
+  const hasNext = items.length > PAGE_SIZE;
+  const events = hasNext ? items.slice(0, PAGE_SIZE) : items;
+
+  function buildPageUrl(p: number) {
+    const params = new URLSearchParams();
+    if (date) params.set("date", date);
+    if (prefecture) params.set("prefecture", prefecture);
+    if (line) params.set("line", line);
+    if (p > 1) params.set("page", String(p));
+    const qs = params.toString();
+    return qs ? `?${qs}` : "?";
+  }
+
+  return (
+    <div className="relative flex min-h-screen flex-col bg-background">
+      <main className="flex-1 px-4 py-8 md:px-6">
+        <div className="mx-auto max-w-5xl space-y-6">
+          <h1 className="text-2xl font-bold">{t("title")}</h1>
+
+          <EventsFilter
+            defaultDate={date}
+            defaultPrefecture={prefecture}
+            defaultLine={line}
+          />
+
+          {events.length === 0 ? (
+            <p className="py-12 text-center text-sm text-muted-foreground">{t("empty")}</p>
+          ) : (
+            <ul className="divide-y rounded-lg border bg-card">
+              {events.map((event) => {
+                const startDate = event.startAt
+                  ? new Date(event.startAt).toLocaleDateString(locale, {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })
+                  : "—";
+
+                const chargeLabel =
+                  event.chargeAmount == null || event.chargeAmount === 0
+                    ? t("charge_free")
+                    : `¥${event.chargeAmount.toLocaleString()}`;
+
+                const seatsLabel =
+                  event.maxParticipants == null
+                    ? null
+                    : event.participantCount >= event.maxParticipants
+                      ? t("seats_full")
+                      : t("seats_remaining", { count: event.maxParticipants - event.participantCount });
+
+                return (
+                  <li key={event.id}>
+                    <Link
+                      href={`/${locale}/dashboard/event/${event.id}`}
+                      className="flex flex-col gap-1 px-4 py-4 transition-colors hover:bg-muted/50 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                    >
+                      <div className="min-w-0 space-y-0.5">
+                        <p className="truncate font-medium">{event.title ?? "—"}</p>
+                        <p className="truncate text-sm text-muted-foreground">{event.orgName}</p>
+                        {event.orgPrefecture && (
+                          <p className="text-xs text-muted-foreground">{event.orgPrefecture}</p>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 flex-wrap items-center gap-2 text-xs text-muted-foreground sm:flex-col sm:items-end sm:gap-0.5">
+                        <span>{startDate}</span>
+                        <span className="font-medium text-foreground">{chargeLabel}</span>
+                        {seatsLabel && (
+                          <span className={event.maxParticipants != null && event.participantCount >= event.maxParticipants ? "text-destructive" : ""}>
+                            {seatsLabel}
+                          </span>
+                        )}
+                      </div>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {(currentPage > 1 || hasNext) && (
+            <div className="flex justify-between">
+              {currentPage > 1 ? (
+                <Link
+                  href={buildPageUrl(currentPage - 1)}
+                  className="inline-flex min-h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium transition-colors hover:bg-muted"
+                >
+                  {t("page_prev")}
+                </Link>
+              ) : (
+                <div />
+              )}
+              {hasNext && (
+                <Link
+                  href={buildPageUrl(currentPage + 1)}
+                  className="inline-flex min-h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium transition-colors hover:bg-muted"
+                >
+                  {t("page_next")}
+                </Link>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+      <AppFooter />
+    </div>
+  );
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -539,3 +539,101 @@ export async function getEventDetail(
     organizerXUrl: row.organizerXUrl ?? null,
   };
 }
+
+export type PublicEventItem = {
+  id: string;
+  title: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  orgId: string;
+  orgName: string;
+  orgAddress: string | null;
+  orgPrefecture: string | null;
+  chargeAmount: number | null;
+  maxParticipants: number | null;
+  participantCount: number;
+};
+
+export type SearchEventsOptions = {
+  date?: string;        // YYYY-MM-DD（この日に開催）
+  prefecture?: string;  // 都道府県
+  line?: string;        // 路線（部分一致）
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * 公開イベントを検索する。未ログインでもアクセス可。
+ * - published かつ start_at が未来のイベントのみ
+ * - 日付・都道府県・路線でフィルタリング可能
+ */
+export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promise<PublicEventItem[]> {
+  const { date, prefecture, line, limit = 20, offset = 0 } = opts;
+  const now = new Date();
+
+  const participantCountSq = db
+    .select({ count: count() })
+    .from(eventParticipations)
+    .where(
+      and(
+        eq(eventParticipations.eventId, events.id),
+        eq(eventParticipations.status, "registered"),
+        isNull(eventParticipations.deletedAt)
+      )
+    );
+
+  const conditions: ReturnType<typeof and>[] = [
+    eq(events.status, "published"),
+    isNull(events.deletedAt),
+    gt(events.startAt, now),
+    isNull(organizations.deletedAt),
+  ];
+
+  if (date) {
+    // start_at の日付部分が一致するもの (UTC日付で比較)
+    conditions.push(sql`DATE(${events.startAt}) = ${date}`);
+  }
+
+  if (prefecture) {
+    conditions.push(eq(organizations.prefecture, prefecture));
+  }
+
+  if (line) {
+    conditions.push(sql`${organizations.nearestLine} ILIKE ${'%' + line + '%'}`);
+  }
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      startAt: events.startAt,
+      endAt: events.endAt,
+      orgId: events.orgId,
+      orgName: organizations.name,
+      orgAddress: organizations.address,
+      orgPrefecture: organizations.prefecture,
+      chargeAmount: events.chargeAmount,
+      maxParticipants: events.maxParticipants,
+      participantCount: sql<number>`(${participantCountSq})`,
+    })
+    .from(events)
+    .innerJoin(organizations, eq(events.orgId, organizations.id))
+    .where(and(...conditions))
+    .orderBy(asc(events.startAt))
+    .limit(limit)
+    .offset(offset);
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    startAt: row.startAt?.toISOString() ?? null,
+    endAt: row.endAt?.toISOString() ?? null,
+    orgId: row.orgId,
+    orgName: row.orgName,
+    orgAddress: row.orgAddress,
+    orgPrefecture: row.orgPrefecture,
+    chargeAmount: row.chargeAmount,
+    maxParticipants: row.maxParticipants,
+    participantCount: Number(row.participantCount),
+  }));
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -6,7 +6,7 @@ import { updateSession } from "./lib/supabase/middleware";
 const intlMiddleware = createMiddleware(routing);
 
 // 認証不要のパス（ロケールプレフィックスを除いた部分）
-const PUBLIC_PATHS = ["/", "/auth/sign-in", "/auth/sign-up", "/auth/callback", "/auth/confirm"];
+const PUBLIC_PATHS = ["/", "/auth/sign-in", "/auth/sign-up", "/auth/callback", "/auth/confirm", "/events"];
 
 function isPublicPath(pathname: string): boolean {
   // /ja/auth/sign-in → /auth/sign-in のようにロケール部分を除去

--- a/packages/db/drizzle/0004_broad_vertigo.sql
+++ b/packages/db/drizzle/0004_broad_vertigo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "organizations" ADD COLUMN "prefecture" text;--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "nearest_line" text;

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1488 @@
+{
+  "id": "9e670604-da7a-43b9-ad42-26cdce50243e",
+  "prevId": "5b3daaee-5562-4000-9f49-b6cbd7cc62bd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_org_id_organizations_id_fk": {
+          "name": "audit_logs_org_id_organizations_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.bar_blocks": {
+      "name": "bar_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bar_blocks_bar_id_organizations_id_fk": {
+          "name": "bar_blocks_bar_id_organizations_id_fk",
+          "tableFrom": "bar_blocks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.bar_host_permissions": {
+      "name": "bar_host_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bar_host_permissions_bar_id_organizations_id_fk": {
+          "name": "bar_host_permissions_bar_id_organizations_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bar_host_permissions_user_id_users_id_fk": {
+          "name": "bar_host_permissions_user_id_users_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bar_host_permissions_granted_by_users_id_fk": {
+          "name": "bar_host_permissions_granted_by_users_id_fk",
+          "tableFrom": "bar_host_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_slug_unique": {
+          "name": "companies_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.coupons": {
+      "name": "coupons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_org_id_organizations_id_fk": {
+          "name": "coupons_org_id_organizations_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_participations": {
+      "name": "event_participations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "participation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registered'"
+        }
+      },
+      "indexes": {
+        "unique_event_participation": {
+          "name": "unique_event_participation",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_participations_event_id_events_id_fk": {
+          "name": "event_participations_event_id_events_id_fk",
+          "tableFrom": "event_participations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_participations_user_id_users_id_fk": {
+          "name": "event_participations_user_id_users_id_fk",
+          "tableFrom": "event_participations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_amount": {
+          "name": "charge_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_org_id_organizations_id_fk": {
+          "name": "events_org_id_organizations_id_fk",
+          "tableFrom": "events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_user_id_users_id_fk": {
+          "name": "events_user_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.fc_relationships": {
+      "name": "fc_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "franchisor_org_id": {
+          "name": "franchisor_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "franchisee_org_id": {
+          "name": "franchisee_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fc_relationships_franchisor_org_id_organizations_id_fk": {
+          "name": "fc_relationships_franchisor_org_id_organizations_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "franchisor_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fc_relationships_franchisee_org_id_organizations_id_fk": {
+          "name": "fc_relationships_franchisee_org_id_organizations_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "franchisee_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fc_relationships_granted_by_users_id_fk": {
+          "name": "fc_relationships_granted_by_users_id_fk",
+          "tableFrom": "fc_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.operator_applications": {
+      "name": "operator_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_name": {
+          "name": "org_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "operator_applications_user_id_users_id_fk": {
+          "name": "operator_applications_user_id_users_id_fk",
+          "tableFrom": "operator_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "operator_applications_reviewed_by_users_id_fk": {
+          "name": "operator_applications_reviewed_by_users_id_fk",
+          "tableFrom": "operator_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "unique_org_owner": {
+          "name": "unique_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "role = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_org_id_organizations_id_fk": {
+          "name": "organization_members_org_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_color": {
+          "name": "image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nearest_line": {
+          "name": "nearest_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_company_id_companies_id_fk": {
+          "name": "organizations_company_id_companies_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.user_coupons": {
+      "name": "user_coupons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_coupons_user_id_users_id_fk": {
+          "name": "user_coupons_user_id_users_id_fk",
+          "tableFrom": "user_coupons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_coupons_coupon_id_coupons_id_fk": {
+          "name": "user_coupons_coupon_id_coupons_id_fk",
+          "tableFrom": "user_coupons",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x_url": {
+          "name": "x_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "published",
+        "cancelled",
+        "rejected"
+      ]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    },
+    "public.participation_status": {
+      "name": "participation_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "cancelled"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "premium"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "venue_user",
+        "system_user"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774157413275,
       "tag": "0003_workable_sphinx",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1774182183336,
+      "tag": "0004_broad_vertigo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -75,6 +75,8 @@ export const organizations = pgTable('organizations', {
   imageColor: text('image_color'), // HEX
   iconUrl: text('icon_url'),
   coverImageUrl: text('cover_image_url'),
+  prefecture: text('prefecture'), // 都道府県
+  nearestLine: text('nearest_line'), // 最寄り路線
 });
 
 export const organizationMembers = pgTable(


### PR DESCRIPTION
## 概要

未ログインでも閲覧できるイベント一覧・検索ページを追加し、ダッシュボードにも公開イベントのプレビューを表示する。

## 変更内容

- `organizations` テーブルに `prefecture`（都道府県）・`nearest_line`（最寄り路線）カラムを追加（マイグレーション含む）
- `searchPublicEvents` クエリを実装（日付・都道府県・路線フィルタ、ページネーション対応）
- `/[locale]/events` ページを新規作成（未ログインアクセス可、Server Component + Client フィルタ）
- ダッシュボードに「開催予定イベント」プレビュー（3件）と「もっと見る」リンクを追加
- `proxy.ts` に `/events` をパブリックパスとして追加
- `ja` / `en` 翻訳キーを追加

## 関連 Issue

Closes #82

## 確認方法

- [ ] 未ログイン状態で `/ja/events` にアクセスできる
- [ ] イベント一覧が表示される（タイトル・バー名・日時・チャージ料）
- [ ] 日付フィルタで絞り込みができる
- [ ] 都道府県フィルタで絞り込みができる
- [ ] 路線フィルタ（部分一致）で絞り込みができる
- [ ] リセットボタンでフィルタが解除される
- [ ] ダッシュボードに「開催予定イベント」（3件）が表示される
- [ ] 「もっと見る →」リンクで `/events` へ遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)