### PR TITLE
feat: イベント一覧の日付フィルターを非表示にし、デフォルトで本日以降の全件を表示する (#117)

### DIFF
--- a/apps/web/src/app/[locale]/events/events-filter.tsx
+++ b/apps/web/src/app/[locale]/events/events-filter.tsx
@@ -5,8 +5,7 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import { DatePicker } from "@/components/ui/date-picker";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 
 const PREFECTURES = [
   "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
@@ -19,26 +18,22 @@ const PREFECTURES = [
 ];
 
 type Props = {
-  defaultDate?: string;
   defaultPrefecture?: string;
   defaultLine?: string;
 };
 
-export function EventsFilter({ defaultDate, defaultPrefecture, defaultLine }: Props) {
+export function EventsFilter({ defaultPrefecture, defaultLine }: Props) {
   const t = useTranslations("events");
-  const locale = useLocale();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
-  const [date, setDate] = useState(defaultDate ?? "");
   const [prefecture, setPrefecture] = useState(defaultPrefecture ?? "");
   const [line, setLine] = useState(defaultLine ?? "");
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const params = new URLSearchParams();
-    if (date) params.set("date", date);
     if (prefecture) params.set("prefecture", prefecture);
     if (line) params.set("line", line);
     startTransition(() => {
@@ -47,7 +42,6 @@ export function EventsFilter({ defaultDate, defaultPrefecture, defaultLine }: Pr
   }
 
   function handleReset() {
-    setDate("");
     setPrefecture("");
     setLine("");
     startTransition(() => {
@@ -55,21 +49,10 @@ export function EventsFilter({ defaultDate, defaultPrefecture, defaultLine }: Pr
     });
   }
 
-  const hasFilters = searchParams.get("date") || searchParams.get("prefecture") || searchParams.get("line");
+  const hasFilters = searchParams.get("prefecture") || searchParams.get("line");
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-medium text-muted-foreground">{t("filter_date")}</label>
-        <DatePicker
-          value={date}
-          onChange={setDate}
-          placeholder={t("filter_date")}
-          locale={locale}
-          clearable
-        />
-      </div>
-
       <div className="flex flex-col gap-1.5">
         <label className="text-xs font-medium text-muted-foreground">{t("filter_prefecture")}</label>
         <Select

--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -9,14 +9,13 @@ import { getUser } from "@/lib/auth";
 const PAGE_SIZE = 20;
 
 type SearchParams = Promise<{
-  date?: string;
   prefecture?: string;
   line?: string;
   page?: string;
 }>;
 
 export default async function EventsPage({ searchParams }: { searchParams: SearchParams }) {
-  const [{ date, prefecture, line, page }, user] = await Promise.all([
+  const [{ prefecture, line, page }, user] = await Promise.all([
     searchParams,
     getUser(),
   ]);
@@ -28,7 +27,6 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
 
   // 1件多く取得してページ送りの有無を判断する
   const items = await searchPublicEvents({
-    date,
     prefecture,
     line,
     limit: PAGE_SIZE + 1,
@@ -40,7 +38,6 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
 
   function buildPageUrl(p: number) {
     const params = new URLSearchParams();
-    if (date) params.set("date", date);
     if (prefecture) params.set("prefecture", prefecture);
     if (line) params.set("line", line);
     if (p > 1) params.set("page", String(p));
@@ -56,7 +53,6 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
           <h1 className="text-2xl font-bold">{t("title")}</h1>
 
           <EventsFilter
-            defaultDate={date}
             defaultPrefecture={prefecture}
             defaultLine={line}
           />

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -569,7 +569,10 @@ export type SearchEventsOptions = {
  */
 export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promise<PublicEventItem[]> {
   const { date, prefecture, line, limit = 20, offset = 0 } = opts;
-  const now = new Date();
+
+  // 本日 00:00:00 UTC 以降のイベントを対象とする
+  const startOfToday = new Date();
+  startOfToday.setUTCHours(0, 0, 0, 0);
 
   const participantCountSq = db
     .select({ count: count() })
@@ -585,7 +588,7 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
   const conditions: ReturnType<typeof and>[] = [
     eq(events.status, "published"),
     isNull(events.deletedAt),
-    gt(events.startAt, now),
+    gte(events.startAt, startOfToday),
     isNull(organizations.deletedAt),
   ];
 


### PR DESCRIPTION
## 概要
イベント一覧 `/events` の「開催日」フィルターを UI から削除し、デフォルトで本日 00:00:00 UTC 以降のイベントを全件表示するよう変更した。

## 変更内容
- `searchPublicEvents`: デフォルトフィルターを `gt(now)` → `gte(startOfToday)` に変更（`setUTCHours(0,0,0,0)` で当日起点）
- `EventsFilter`: `date` state・`DatePicker` JSX・`defaultDate` prop を削除
- `events/page.tsx`: `SearchParams` から `date` を削除、`EventsFilter` への `defaultDate` prop を削除

## 関連 Issue
Closes #117

## 確認方法
- [ ] `/events` ページに「開催日」フィルターが表示されないこと
- [ ] 都道府県・路線フィルターは引き続き動作すること
- [ ] フィルターなしで本日以降のイベントが全件表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)