### PR TITLE
revert: postgres-js ドライバーに戻す（Supabase 環境では @neondatabase/serverless 非対応）

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@e-be/db": "workspace:*",
-    "@neondatabase/serverless": "0.10.4",
+    "postgres": "^3.4.4",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.3",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/[locale]/admin/applications/actions.ts
+++ b/apps/web/src/app/[locale]/admin/applications/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { db, dbWs } from "@/lib/db";
+import { db } from "@/lib/db";
 import {
   operatorApplications,
   companies,
@@ -28,8 +28,7 @@ export async function approveApplication(
   const locale = String(formData.get("locale") ?? "ja");
 
   // トランザクション: 会社 → 組織 → メンバー → userType 更新 → 申請ステータス更新
-  // HTTP ドライバーはトランザクション非対応のため WebSocket ドライバー (dbWs) を使用
-  await dbWs.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     // 1. companies に insert
     const [company] = await tx
       .insert(companies)

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -1,21 +1,11 @@
-import { neon, Pool } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-http';
-import { drizzle as drizzleWs } from 'drizzle-orm/neon-serverless';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
 import * as schema from '@e-be/db/schema';
 
 // サーバーサイド専用 — クライアントバンドルに含まれないよう注意
-// HTTP ドライバー: コネクションレスで各クエリを HTTP リクエストとして送信。
-// コールドスタート時の TCP 接続確立コストがなく高速。
-function getDb() {
-  const sql = neon(process.env.DATABASE_URL!);
-  return drizzle(sql, { schema });
-}
-export const db = getDb();
-
-// WebSocket ドライバー: トランザクションが必要な処理専用。
-// HTTP ドライバーはトランザクション非対応のため、Pool + neon-serverless を使用する。
-function getDbWs() {
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL! });
-  return drizzleWs(pool, { schema });
-}
-export const dbWs = getDbWs();
+// Vercel Serverless では関数インスタンスごとに接続を使い回すため prepare: false が必要
+const client = postgres(process.env.DATABASE_URL!, {
+  max: 1,
+  prepare: false, // Neon の pgbouncer プーラーに対応
+});
+export const db = drizzle(client, { schema });

--- a/apps/web/src/lib/withdrawal.ts
+++ b/apps/web/src/lib/withdrawal.ts
@@ -1,5 +1,5 @@
 import { and, eq, gt, isNull } from 'drizzle-orm';
-import { db, dbWs } from './db';
+import { db } from './db';
 import {
   users,
   organizationMembers,
@@ -58,8 +58,7 @@ export async function checkWithdrawalBlockers(
 export async function withdrawUser(dbUserId: string): Promise<void> {
   const now = new Date();
 
-  // HTTP ドライバーはトランザクション非対応のため WebSocket ドライバー (dbWs) を使用
-  await dbWs.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     // ブロック条件の最終チェック（競合対策）
     const [ownerCheck, eventCheck] = await Promise.all([
       tx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@e-be/db':
         specifier: workspace:*
         version: link:../../packages/db
-      '@neondatabase/serverless':
-        specifier: 0.10.4
-        version: 0.10.4
       '@supabase/ssr':
         specifier: ^0.9.0
         version: 0.9.0(@supabase/supabase-js@2.99.3)
@@ -40,7 +37,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: ^0.33.0
-        version: 0.33.0(@neondatabase/serverless@0.10.4)(@types/pg@8.20.0)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+        version: 0.33.0(@neondatabase/serverless@1.0.2)(@types/pg@8.20.0)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -50,6 +47,9 @@ importers:
       next-intl:
         specifier: ^4.8.3
         version: 4.8.3(next@16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      postgres:
+        specifier: ^3.4.4
+        version: 3.4.8
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1288,9 +1288,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@neondatabase/serverless@0.10.4':
-    resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
-
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
@@ -1894,9 +1891,6 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
-
-  '@types/pg@8.11.6':
-    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -3907,9 +3901,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obuf@1.1.2:
-    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4012,20 +4003,12 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-numeric@1.0.2:
-    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
-    engines: {node: '>=4'}
-
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
-
-  pg-types@4.1.0:
-    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
-    engines: {node: '>=10'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4090,36 +4073,17 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
-  postgres-array@3.0.4:
-    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
-    engines: {node: '>=12'}
-
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
-
-  postgres-bytea@3.0.0:
-    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
-    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
-  postgres-date@2.1.0:
-    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
-    engines: {node: '>=12'}
-
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
-
-  postgres-interval@3.0.0:
-    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
-    engines: {node: '>=12'}
-
-  postgres-range@1.1.4:
-    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.8:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
@@ -5974,10 +5938,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neondatabase/serverless@0.10.4':
-    dependencies:
-      '@types/pg': 8.11.6
-
   '@neondatabase/serverless@1.0.2':
     dependencies:
       '@types/node': 22.19.15
@@ -6458,12 +6418,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
     optional: true
-
-  '@types/pg@8.11.6':
-    dependencies:
-      '@types/node': 20.19.37
-      pg-protocol: 1.13.0
-      pg-types: 4.1.0
 
   '@types/pg@8.20.0':
     dependencies:
@@ -7226,14 +7180,6 @@ snapshots:
       esbuild-register: 3.6.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
-
-  drizzle-orm@0.33.0(@neondatabase/serverless@0.10.4)(@types/pg@8.20.0)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4):
-    optionalDependencies:
-      '@neondatabase/serverless': 0.10.4
-      '@types/pg': 8.20.0
-      '@types/react': 19.2.14
-      postgres: 3.4.8
-      react: 19.2.4
 
   drizzle-orm@0.33.0(@neondatabase/serverless@1.0.2)(@types/pg@8.20.0)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
@@ -8668,8 +8614,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obuf@1.1.2: {}
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -8775,11 +8719,11 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
-  pg-int8@1.0.1: {}
+  pg-int8@1.0.1:
+    optional: true
 
-  pg-numeric@1.0.2: {}
-
-  pg-protocol@1.13.0: {}
+  pg-protocol@1.13.0:
+    optional: true
 
   pg-types@2.2.0:
     dependencies:
@@ -8789,16 +8733,6 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
     optional: true
-
-  pg-types@4.1.0:
-    dependencies:
-      pg-int8: 1.0.1
-      pg-numeric: 1.0.2
-      postgres-array: 3.0.4
-      postgres-bytea: 3.0.0
-      postgres-date: 2.1.0
-      postgres-interval: 3.0.0
-      postgres-range: 1.1.4
 
   picocolors@1.1.1: {}
 
@@ -8847,31 +8781,18 @@ snapshots:
   postgres-array@2.0.0:
     optional: true
 
-  postgres-array@3.0.4: {}
-
   postgres-bytea@1.0.1:
     optional: true
 
-  postgres-bytea@3.0.0:
-    dependencies:
-      obuf: 1.1.2
-
   postgres-date@1.0.7:
     optional: true
-
-  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
     optional: true
 
-  postgres-interval@3.0.0: {}
-
-  postgres-range@1.1.4: {}
-
-  postgres@3.4.8:
-    optional: true
+  postgres@3.4.8: {}
 
   powershell-utils@0.1.0: {}
 


### PR DESCRIPTION
## 概要

#120（DB ドライバー移行）と #123（バージョン固定）を取り消す。

## 原因

このプロジェクトは **Supabase** を使用しているため、**Neon 専用**の `@neondatabase/serverless` HTTP ドライバーは使えない。

- `neon()` 関数は Neon の HTTP API（`api.neon.tech`）にクエリを送信する
- `DATABASE_URL` が Supabase の接続文字列のため `ENOTFOUND api.pooler.supabase.com` で 500 エラーになった

## 変更内容

- `lib/db.ts` を `postgres-js` + `drizzle-orm/postgres-js` に戻す
- `withdrawal.ts`, `actions.ts` のトランザクションを `db.transaction()` に戻す
- `apps/web/package.json` を `postgres: ^3.4.4` に戻す（`@neondatabase/serverless` 削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)