### PR TITLE
fix: toLocaleString に locale を渡してハイドレーションミスマッチを修正

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organizer-history-item.tsx
@@ -98,14 +98,14 @@ export function OrganizerHistoryItem({ event, locale }: Props) {
           {t('organizer_history_charge')}:{' '}
           <span className="font-medium text-foreground">
             {event.chargeAmount != null
-              ? `¥${event.chargeAmount.toLocaleString()}`
+              ? `¥${event.chargeAmount.toLocaleString(locale)}`
               : '—'}
           </span>
         </span>
         <span className="text-xs text-muted-foreground">
           {t('organizer_history_sales')}:{' '}
           <span className="font-medium text-foreground">
-            {salesAmount != null ? `¥${salesAmount.toLocaleString()}` : '—'}
+            {salesAmount != null ? `¥${salesAmount.toLocaleString(locale)}` : '—'}
           </span>
         </span>
       </div>


### PR DESCRIPTION
## 概要

本番の `console.error` で出ていた React error #418 (Hydration mismatch) を修正。

## 原因

`organizer-history-item.tsx`（`'use client'` コンポーネント）で `.toLocaleString()` を locale 指定なしで使用していた。

- **サーバー（Node.js）**: デフォルトロケール（`en-US` 等）で数値フォーマット → `"1,234"`
- **ブラウザ（日本語環境など）**: ユーザーのロケールで数値フォーマット → 異なる場合がある

この不一致が React の SSR HTML とクライアントの hydration 結果のズレを引き起こし `#418` エラーになる。

## 修正

`toLocaleString()` → `toLocaleString(locale)` に統一（`locale` は props 経由で渡されている）

## 404 エラーについて

`Failed to load resource: 404` は別の問題。新デプロイ後に古いページが新チャンクを参照できないキャッシュ起因で、ユーザーがページをリロードすれば解消する。これは Next.js の仕様でありコードの修正は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)