### PR TITLE
feat: イベント検索の地域フィルターを都道府県から9広域エリアに変更

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -408,7 +408,7 @@
   "events": {
     "title": "Events",
     "filter_date": "Date",
-    "filter_prefecture": "Prefecture",
+    "filter_area": "Area",
     "filter_line": "Train Line",
     "filter_search": "Search",
     "filter_reset": "Reset",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -408,7 +408,7 @@
   "events": {
     "title": "イベント一覧",
     "filter_date": "開催日",
-    "filter_prefecture": "都道府県",
+    "filter_area": "エリア",
     "filter_line": "路線",
     "filter_search": "検索",
     "filter_reset": "リセット",

--- a/apps/web/src/app/[locale]/events/events-filter.tsx
+++ b/apps/web/src/app/[locale]/events/events-filter.tsx
@@ -5,36 +5,27 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { useTranslations } from "next-intl";
-
-const PREFECTURES = [
-  "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
-  "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
-  "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県",
-  "静岡県", "愛知県", "三重県", "滋賀県", "京都府", "大阪府", "兵庫県",
-  "奈良県", "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県",
-  "徳島県", "香川県", "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県",
-  "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県",
-];
+import { AREA_KEYS, AREA_REGIONS } from "@/lib/area-regions";
 
 type Props = {
-  defaultPrefecture?: string;
+  defaultArea?: string;
   defaultLine?: string;
   availableLines?: string[];
 };
 
-export function EventsFilter({ defaultPrefecture, defaultLine, availableLines = [] }: Props) {
+export function EventsFilter({ defaultArea, defaultLine, availableLines = [] }: Props) {
   const t = useTranslations("events");
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
-  const [prefecture, setPrefecture] = useState(defaultPrefecture ?? "");
+  const [area, setArea] = useState(defaultArea ?? "");
   const [line, setLine] = useState(defaultLine ?? "");
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const params = new URLSearchParams();
-    if (prefecture) params.set("prefecture", prefecture);
+    if (area) params.set("area", area);
     if (line) params.set("line", line);
     startTransition(() => {
       router.push(`?${params.toString()}`);
@@ -42,27 +33,27 @@ export function EventsFilter({ defaultPrefecture, defaultLine, availableLines = 
   }
 
   function handleReset() {
-    setPrefecture("");
+    setArea("");
     setLine("");
     startTransition(() => {
       router.push("?");
     });
   }
 
-  const hasFilters = searchParams.get("prefecture") || searchParams.get("line");
+  const hasFilters = searchParams.get("area") || searchParams.get("line");
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
       <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-medium text-muted-foreground">{t("filter_prefecture")}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t("filter_area")}</label>
         <Select
-          value={prefecture}
-          onChange={(e) => setPrefecture(e.target.value)}
+          value={area}
+          onChange={(e) => setArea(e.target.value)}
           className="w-full sm:w-40"
         >
           <option value="">—</option>
-          {PREFECTURES.map((p) => (
-            <option key={p} value={p}>{p}</option>
+          {AREA_KEYS.map((key) => (
+            <option key={key} value={key}>{AREA_REGIONS[key].label}</option>
           ))}
         </Select>
       </div>

--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -10,13 +10,13 @@ import { getUser } from "@/lib/auth";
 const PAGE_SIZE = 20;
 
 type SearchParams = Promise<{
-  prefecture?: string;
+  area?: string;
   line?: string;
   page?: string;
 }>;
 
 export default async function EventsPage({ searchParams }: { searchParams: SearchParams }) {
-  const [{ prefecture, line, page }, user, availableLines] = await Promise.all([
+  const [{ area, line, page }, user, availableLines] = await Promise.all([
     searchParams,
     getUser(),
     getAvailableLines(),
@@ -29,7 +29,7 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
 
   // 1件多く取得してページ送りの有無を判断する
   const items = await searchPublicEvents({
-    prefecture,
+    area,
     line,
     limit: PAGE_SIZE + 1,
     offset,
@@ -40,7 +40,7 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
 
   function buildPageUrl(p: number) {
     const params = new URLSearchParams();
-    if (prefecture) params.set("prefecture", prefecture);
+    if (area) params.set("area", area);
     if (line) params.set("line", line);
     if (p > 1) params.set("page", String(p));
     const qs = params.toString();
@@ -55,7 +55,7 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
           <h1 className="text-2xl font-bold">{t("title")}</h1>
 
           <EventsFilter
-            defaultPrefecture={prefecture}
+            defaultArea={area}
             defaultLine={line}
             availableLines={availableLines}
           />

--- a/apps/web/src/lib/area-regions.ts
+++ b/apps/web/src/lib/area-regions.ts
@@ -1,0 +1,55 @@
+export type AreaKey =
+  | "metropolitan"
+  | "shizuoka"
+  | "chubu"
+  | "kyushu"
+  | "hokkaido"
+  | "miyagi"
+  | "osaka"
+  | "kansai"
+  | "chugoku";
+
+export const AREA_REGIONS: Record<AreaKey, { label: string; prefectures: string[] }> = {
+  metropolitan: {
+    label: "首都圏",
+    prefectures: ["東京都", "神奈川県", "埼玉県", "千葉県", "茨城県", "栃木県", "群馬県", "山梨県"],
+  },
+  shizuoka: {
+    label: "静岡",
+    prefectures: ["静岡県"],
+  },
+  chubu: {
+    label: "愛知（中部）",
+    prefectures: ["愛知県", "岐阜県", "三重県"],
+  },
+  kyushu: {
+    label: "九州",
+    prefectures: ["福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県"],
+  },
+  hokkaido: {
+    label: "北海道",
+    prefectures: ["北海道"],
+  },
+  miyagi: {
+    label: "宮城",
+    prefectures: ["宮城県"],
+  },
+  osaka: {
+    label: "大阪",
+    prefectures: ["大阪府"],
+  },
+  kansai: {
+    label: "その他関西",
+    prefectures: ["京都府", "兵庫県", "奈良県", "和歌山県", "滋賀県"],
+  },
+  chugoku: {
+    label: "中国地方",
+    prefectures: ["鳥取県", "島根県", "岡山県", "広島県", "山口県"],
+  },
+};
+
+export const AREA_KEYS = Object.keys(AREA_REGIONS) as AreaKey[];
+
+export function areaKeyToPrefectures(areaKey: string): string[] {
+  return AREA_REGIONS[areaKey as AreaKey]?.prefectures ?? [];
+}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { events, eventParticipations, organizations, barHostPermissions, barBlocks, users } from "@e-be/db/schema";
 import { eq, and, gte, lte, isNull, or, lt, gt, asc, desc, ne, inArray, count, sql, isNotNull } from "drizzle-orm";
 import { getLinesByStation, getStationsByLine } from "@e-be/db/station-lines";
+import { areaKeyToPrefectures } from "@/lib/area-regions";
 
 /**
  * イベント作成フォームのバー選択用に公開バー一覧を取得する。
@@ -562,9 +563,9 @@ export type PublicEventItem = {
 };
 
 export type SearchEventsOptions = {
-  date?: string;        // YYYY-MM-DD（この日に開催）
-  prefecture?: string;  // 都道府県
-  line?: string;        // 路線名（マスタ完全一致）
+  date?: string;    // YYYY-MM-DD（この日に開催）
+  area?: string;    // 広域エリアキー
+  line?: string;    // 路線名（マスタ完全一致）
   limit?: number;
   offset?: number;
 };
@@ -575,7 +576,7 @@ export type SearchEventsOptions = {
  * - 日付・都道府県・路線でフィルタリング可能
  */
 export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promise<PublicEventItem[]> {
-  const { date, prefecture, line, limit = 20, offset = 0 } = opts;
+  const { date, area, line, limit = 20, offset = 0 } = opts;
 
   // 本日 00:00:00 UTC 以降のイベントを対象とする
   const startOfToday = new Date();
@@ -604,8 +605,13 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
     conditions.push(sql`DATE(${events.startAt}) = ${date}`);
   }
 
-  if (prefecture) {
-    conditions.push(eq(organizations.prefecture, prefecture));
+  if (area) {
+    const prefectures = areaKeyToPrefectures(area);
+    if (prefectures.length > 0) {
+      conditions.push(inArray(organizations.prefecture, prefectures));
+    } else {
+      conditions.push(sql`FALSE`);
+    }
   }
 
   if (line) {


### PR DESCRIPTION
## 概要

イベント検索の地域フィルターを 46 都道府県から 9 つの広域エリアに変更する。DB スキーマ変更なし、フロント側のマッピングで対応。

## 変更内容

- `apps/web/src/lib/area-regions.ts` を新規作成（9エリアの定数・`areaKeyToPrefectures()` 関数）
- `events.ts`: `SearchEventsOptions.prefecture` → `area` に変更、`inArray()` で複数都道府県対応
- `events-filter.tsx`: 46都道府県リストを削除し、`AREA_REGIONS` のエリア選択に置き換え
- `page.tsx`: `searchParams.prefecture` → `area`、`EventsFilter` props を `defaultArea` に統一
- 翻訳キーを `filter_prefecture` → `filter_area` に変更（ja: "エリア" / en: "Area"）

## 関連 Issue

Closes #130

## 確認方法

- [ ] `/ja/events` にアクセスしてフィルターに 9 エリアが表示されること（46 都道府県は表示されない）
- [ ] 「首都圏」を選択して検索すると URL が `?area=metropolitan` になり、東京・神奈川等のイベントのみ表示されること
- [ ] 「大阪」を選択して検索すると大阪府のイベントのみ表示されること
- [ ] エリア未選択で検索すると全イベントが表示されること
- [ ] 「リセット」ボタンで全イベントが再表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)