### PR TITLE
fix: nearestStation に50文字の上限バリデーションを追加する

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -277,6 +277,7 @@ export function EventEditForm({ event, eventId, hasPermission, locale, bars }: P
               name="nearestStation"
               defaultValue={event.nearestStation ?? ""}
               placeholder={t("field_nearest_station_placeholder")}
+              maxLength={50}
               disabled={isPending}
             />
           </div>

--- a/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/create/event-create-form.tsx
@@ -111,6 +111,7 @@ export function EventCreateForm({ bars, locale }: Props) {
               id="nearestStation"
               name="nearestStation"
               placeholder={t("field_nearest_station_placeholder")}
+              maxLength={50}
               disabled={isPending}
             />
           </div>

--- a/apps/web/src/lib/actions/event.ts
+++ b/apps/web/src/lib/actions/event.ts
@@ -27,6 +27,7 @@ export async function createEventDraft(formData: FormData): Promise<CreateEventD
   if (!orgId || !/^[0-9a-f-]{36}$/.test(orgId)) return { error: 'invalid' };
   if (!title || title.length > 100) return { error: 'invalid' };
   if (!description || description.length > 2000) return { error: 'invalid' };
+  if (nearestStation && nearestStation.length > 50) return { error: 'invalid' };
 
   let maxParticipants: number | null = null;
   if (maxParticipantsRaw && maxParticipantsRaw !== '') {
@@ -69,6 +70,7 @@ export async function updateEventDraft(eventId: string, formData: FormData): Pro
 
   if (!title || title.length > 100) return { error: 'invalid' };
   if (!description || description.length > 2000) return { error: 'invalid' };
+  if (nearestStation && nearestStation.length > 50) return { error: 'invalid' };
 
   const orgId = orgIdRaw && /^[0-9a-f-]{36}$/.test(orgIdRaw) ? orgIdRaw : undefined;
 


### PR DESCRIPTION
## 概要

イベント作成・編集の `nearestStation` フィールドに、他フィールドと同様の文字数上限バリデーションを追加する。

## 変更内容

- `event.ts` の `createEventDraft` / `updateEventDraft` に `nearestStation` が 50文字超の場合 `{ error: 'invalid' }` を返すバリデーションを追加
- `event-create-form.tsx` の nearestStation `<Input>` に `maxLength={50}` を追加
- `event-edit-form.tsx` の nearestStation `<Input>` に `maxLength={50}` を追加

## 関連 Issue

Closes #122

## 確認方法

- [ ] イベント作成フォームの最寄り駅欄に51文字以上入力できないこと（UI制限）
- [ ] イベント編集フォームの最寄り駅欄に51文字以上入力できないこと（UI制限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)