### PR TITLE
feat: Select UI を shadcn/ui に置き換え・/events 路線フィルタを非表示 (#133)

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/edit/event-edit-form.tsx
@@ -10,7 +10,13 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Select } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { updateEventDraft, submitEvent, publishEvent } from "@/lib/actions/event";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -175,15 +181,21 @@ export function EventEditForm({ event, eventId, hasPermission, locale, bars }: P
             {isDraft ? (
               <Select
                 value={orgId}
-                onChange={(e) => setOrgId(e.target.value)}
+                onValueChange={(val) => setOrgId(val ?? "")}
                 disabled={isPending}
               >
-                <option value="" disabled>{t("field_venue_placeholder")}</option>
-                {bars.map((bar) => (
-                  <option key={bar.id} value={bar.id}>
-                    {bar.name}
-                  </option>
-                ))}
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {orgId ? (bars.find((b) => b.id === orgId)?.name) : t("field_venue_placeholder")}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {bars.map((bar) => (
+                    <SelectItem key={bar.id} value={bar.id}>
+                      {bar.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
             ) : (
               <p className="rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">

--- a/apps/web/src/app/[locale]/events/events-filter.tsx
+++ b/apps/web/src/app/[locale]/events/events-filter.tsx
@@ -3,9 +3,15 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
-import { Select } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useTranslations } from "next-intl";
-import { AREA_KEYS, AREA_REGIONS } from "@/lib/area-regions";
+import { AREA_KEYS, AREA_REGIONS, type AreaKey } from "@/lib/area-regions";
 
 type Props = {
   defaultArea?: string;
@@ -46,30 +52,32 @@ export function EventsFilter({ defaultArea, defaultLine, availableLines = [] }: 
     <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
       <div className="flex flex-col gap-1.5">
         <label className="text-xs font-medium text-muted-foreground">{t("filter_area")}</label>
-        <Select
-          value={area}
-          onChange={(e) => setArea(e.target.value)}
-          className="w-full sm:w-40"
-        >
-          <option value="">—</option>
-          {AREA_KEYS.map((key) => (
-            <option key={key} value={key}>{AREA_REGIONS[key].label}</option>
-          ))}
+        <Select value={area} onValueChange={(val) => setArea(val ?? "")}>
+          <SelectTrigger className="w-full sm:w-40">
+            <SelectValue>
+              {area ? AREA_REGIONS[area as AreaKey]?.label : "—"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {AREA_KEYS.map((key) => (
+              <SelectItem key={key} value={key}>{AREA_REGIONS[key].label}</SelectItem>
+            ))}
+          </SelectContent>
         </Select>
       </div>
 
-      {availableLines.length > 0 && (
+      {false && availableLines.length > 0 && (
         <div className="flex flex-col gap-1.5">
           <label className="text-xs font-medium text-muted-foreground">{t("filter_line")}</label>
-          <Select
-            value={line}
-            onChange={(e) => setLine(e.target.value)}
-            className="w-full sm:w-48"
-          >
-            <option value="">—</option>
-            {availableLines.map((l) => (
-              <option key={l} value={l}>{l}</option>
-            ))}
+          <Select value={line || undefined} onValueChange={(val) => setLine(val ?? "")}>
+            <SelectTrigger className="w-full sm:w-48">
+              <SelectValue placeholder="—" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableLines.map((l) => (
+                <SelectItem key={l} value={l}>{l}</SelectItem>
+              ))}
+            </SelectContent>
           </Select>
         </div>
       )}

--- a/apps/web/src/components/ui/date-time-picker.tsx
+++ b/apps/web/src/components/ui/date-time-picker.tsx
@@ -13,7 +13,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Select } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface DateTimePickerProps {
   id?: string;
@@ -78,15 +84,17 @@ export function DateTimePicker({
     setOpen(false);
   };
 
-  const handleHourChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newHour = parseInt(e.target.value, 10);
+  const handleHourChange = (val: string | null) => {
+    if (!val) return;
+    const newHour = parseInt(val, 10);
     if (date) {
       updateDateTime(date, newHour, minute);
     }
   };
 
-  const handleMinuteChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newMinute = parseInt(e.target.value, 10);
+  const handleMinuteChange = (val: string | null) => {
+    if (!val) return;
+    const newMinute = parseInt(val, 10);
     if (date) {
       updateDateTime(date, hour, newMinute);
     }
@@ -129,29 +137,37 @@ export function DateTimePicker({
 
         <div className="flex items-center gap-1">
           <Select
-            value={hour}
-            onChange={handleHourChange}
-            className="w-[64px]"
+            value={hour.toString()}
+            onValueChange={handleHourChange}
             disabled={disabled || !date}
           >
-            {Array.from({ length: 24 }).map((_, i) => (
-              <option key={i} value={i}>
-                {i.toString().padStart(2, "0")}
-              </option>
-            ))}
+            <SelectTrigger className="w-[64px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 24 }).map((_, i) => (
+                <SelectItem key={i} value={i.toString()}>
+                  {i.toString().padStart(2, "0")}
+                </SelectItem>
+              ))}
+            </SelectContent>
           </Select>
           <span className="text-muted-foreground">:</span>
           <Select
-            value={minute}
-            onChange={handleMinuteChange}
-            className="w-[64px]"
+            value={minute.toString()}
+            onValueChange={handleMinuteChange}
             disabled={disabled || !date}
           >
-            {[0, 15, 30, 45].map((m) => (
-              <option key={m} value={m}>
-                {m.toString().padStart(2, "0")}
-              </option>
-            ))}
+            <SelectTrigger className="w-[64px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[0, 15, 30, 45].map((m) => (
+                <SelectItem key={m} value={m.toString()}>
+                  {m.toString().padStart(2, "0")}
+                </SelectItem>
+              ))}
+            </SelectContent>
           </Select>
         </div>
       </div>

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,18 +1,201 @@
+"use client"
+
 import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
-function Select({ className, ...props }: React.ComponentProps<"select">) {
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (
-    <select
-      data-slot="select"
-      className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80",
-        className
-      )}
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
       {...props}
     />
   )
 }
 
-export { Select }
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}


### PR DESCRIPTION
## 概要

ネイティブ `<select>` ラッパーを shadcn/ui（Base UI）の Select コンポーネントに置き換え、タップしやすく視認性の高い UI に改善する。また /events の路線フィルタは UI 未整備のため非表示にする。

## 変更内容

- `select.tsx`: ネイティブ select ラッパーを Base UI ベースの shadcn/ui Select（SelectTrigger / SelectContent / SelectItem 等）に置き換え
- `events-filter.tsx`: エリアフィルタを shadcn/ui Select に移行、路線フィルタを `{false && ...}` で非表示
- `event-edit-form.tsx`: 会場選択を shadcn/ui Select に移行
- `date-time-picker.tsx`: 時・分セレクトも新 API（`onValueChange`）に対応

## 関連 Issue

Closes #133

## 確認方法

- [ ] `/events` ページのエリアドロップダウンが shadcn/ui Select で表示される
- [ ] エリア選択後に日本語ラベル（「首都圏」等）が正しく表示される
- [ ] `/events` ページに路線フィルタが表示されない
- [ ] ダッシュボードのイベント編集フォームで会場選択が正常に動作する
- [ ] DateTimePicker の時・分セレクトが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)