### PR TITLE
chore: next/image の remotePatterns に *.supabase.co を追加

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,6 +7,11 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? "development",
   },
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "*.supabase.co" },
+    ],
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## 概要

`next.config.ts` に `images.remotePatterns` を追加し、Supabase Storage の画像 URL を `next/image` で安全に表示できるようにする。

## 変更内容

- `apps/web/next.config.ts` に `images.remotePatterns: [{ protocol: 'https', hostname: '*.supabase.co' }]` を追加

## 関連 Issue

Closes #129

## 確認方法

- [ ] `next.config.ts` に `remotePatterns` が存在すること
- [ ] `*.supabase.co` の HTTPS 画像が `next/image` でエラーなく表示されること（thumbnailUrl 実装後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)