### PR TITLE
feat: イベント詳細の開催店舗名を /stores/[slug] へのリンクにする

### DIFF
--- a/.claude/steering/issue-141-store-link-from-event-detail.md
+++ b/.claude/steering/issue-141-store-link-from-event-detail.md
@@ -1,0 +1,78 @@
+# Issue #141: stores への導線を追加する
+
+## 背景
+
+`/stores/[slug]` ページは実装済みだが、どこからもリンクされていない。
+イベント詳細ページ（ダッシュボード・公開）の「開催店舗」セクションから店舗ページへリンクする。
+
+## 参照
+
+- GitHub Issue: #141
+- 関連ステアリング: `issue-136-public-store-detail-page.md`
+- 変更対象:
+  - `apps/web/src/lib/events.ts` — `EventDetail` 型 / `getEventDetail`
+  - `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+  - `apps/web/src/app/[locale]/events/[eventId]/page.tsx`
+
+## 実装方針
+
+### 1. `getEventDetail` に `orgSlug` を追加
+
+`apps/web/src/lib/events.ts` の SELECT に `organizations.slug as orgSlug` を追加し、
+`EventDetail` 型に `orgSlug: string | null` を追加する。
+
+```ts
+// SELECT に追加
+orgSlug: organizations.slug,
+
+// 戻り値に追加
+orgSlug: row.orgSlug ?? null,
+```
+
+### 2. ダッシュボード イベント詳細ページ
+
+`apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+
+「開催店舗」セクションの店舗名を、`orgSlug` がある場合は `/stores/[slug]` へのリンクにする。
+
+```tsx
+{event.orgSlug ? (
+  <Link href={`/${locale}/stores/${event.orgSlug}`} className="font-medium hover:underline">
+    {event.orgName}
+  </Link>
+) : (
+  <p className="font-medium">{event.orgName}</p>
+)}
+```
+
+### 3. 公開 イベント詳細ページ
+
+`apps/web/src/app/[locale]/events/[eventId]/page.tsx` も同様に対応する。
+（公開ページの `EventDetail` 型・クエリも同じ `getEventDetail` を使用しているため、型変更のみで対応可能）
+
+## 実装ステップ
+
+1. `apps/web/src/lib/events.ts`
+   - `EventDetail` 型に `orgSlug: string | null` を追加
+   - `getEventDetail` の SELECT に `orgSlug: organizations.slug` を追加
+   - 戻り値マッピングに `orgSlug: row.orgSlug ?? null` を追加
+
+2. `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+   - 「開催店舗」の店舗名を条件付きリンクに変更
+
+3. `apps/web/src/app/[locale]/events/[eventId]/page.tsx`
+   - 同様に「開催店舗」の店舗名を条件付きリンクに変更
+
+## 受け入れ条件
+
+- [ ] ダッシュボードのイベント詳細で開催店舗名が `/stores/[slug]` へのリンクになっている
+- [ ] 公開イベント詳細でも同様にリンクになっている
+- [ ] `orgSlug` が null の場合はリンクなしのテキスト表示にフォールバックする
+- [ ] 既存の表示スタイルを壊さない
+
+## 影響範囲
+
+- `apps/web/src/lib/events.ts`（型・クエリ変更）
+- `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+- `apps/web/src/app/[locale]/events/[eventId]/page.tsx`
+- 翻訳キー追加なし（既存の `venue` キーをそのまま使用）

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -141,7 +141,16 @@ export default async function EventDetailPage({ params }: Props) {
               <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
                 {t("venue")}
               </p>
-              <p className="font-medium">{event.orgName}</p>
+              {event.orgSlug ? (
+                <Link
+                  href={`/${locale}/stores/${event.orgSlug}`}
+                  className="font-medium hover:underline"
+                >
+                  {event.orgName}
+                </Link>
+              ) : (
+                <p className="font-medium">{event.orgName}</p>
+              )}
               {event.orgAddress && (
                 <p className="text-sm text-muted-foreground">{event.orgAddress}</p>
               )}

--- a/apps/web/src/app/[locale]/events/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/events/[eventId]/page.tsx
@@ -138,7 +138,16 @@ export default async function PublicEventDetailPage({ params }: Props) {
                 <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
                   {t("venue")}
                 </p>
-                <p className="font-medium">{event.orgName}</p>
+                {event.orgSlug ? (
+                  <Link
+                    href={`/${locale}/stores/${event.orgSlug}`}
+                    className="font-medium hover:underline"
+                  >
+                    {event.orgName}
+                  </Link>
+                ) : (
+                  <p className="font-medium">{event.orgName}</p>
+                )}
                 {event.orgAddress && (
                   <p className="text-sm text-muted-foreground">{event.orgAddress}</p>
                 )}

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -451,6 +451,7 @@ export type EventDetail = {
   location: string | null;
   chargeAmount: number | null;
   orgName: string;
+  orgSlug: string | null;
   orgAddress: string | null;
   myParticipationStatus: "registered" | "cancelled" | null;
   participantCount: number;
@@ -497,6 +498,7 @@ export async function getEventDetail(
       chargeAmount: events.chargeAmount,
       maxParticipants: events.maxParticipants,
       orgName: organizations.name,
+      orgSlug: organizations.slug,
       orgAddress: organizations.address,
       participationStatus: eventParticipations.status,
       organizerUserId: events.userId,
@@ -538,6 +540,7 @@ export async function getEventDetail(
     chargeAmount: row.chargeAmount ?? null,
     maxParticipants: row.maxParticipants ?? null,
     orgName: row.orgName,
+    orgSlug: row.orgSlug ?? null,
     orgAddress: row.orgAddress,
     myParticipationStatus: row.participationStatus ?? null,
     participantCount,


### PR DESCRIPTION
## 概要

closes #141

イベント詳細ページ（ダッシュボード・公開）の「開催店舗」セクションに `/stores/[slug]` への導線を追加。

## 変更内容

- `EventDetail` 型に `orgSlug: string | null` を追加
- `getEventDetail` の SELECT に `organizations.slug` を追加
- ダッシュボード・公開イベント詳細ページの店舗名を条件付きリンクに変更
  - `orgSlug` がある場合 → `/stores/[slug]` へのリンク
  - `orgSlug` が null の場合 → テキストにフォールバック

## 確認事項

- [x] TypeScript エラーなし（`tsc --noEmit` 通過）
- [x] ダッシュボード イベント詳細の開催店舗名がリンクになっている
- [x] 公開イベント詳細の開催店舗名がリンクになっている
- [x] slug が null の場合はテキスト表示にフォールバック