### PR TITLE
feat: イベント一覧カードの店舗名を /stores/[slug] へのリンクにする

### DIFF
--- a/.claude/steering/issue-138-store-link-from-events-list.md
+++ b/.claude/steering/issue-138-store-link-from-events-list.md
@@ -1,0 +1,94 @@
+# Issue #138: イベント一覧カードから店舗詳細ページへのリンク追加
+
+## 背景
+
+`/stores/[slug]` ページは実装済み（#136）。
+イベント詳細ページの店舗リンクは #141 で対応済み。
+残りはイベント一覧カード（EventsList）の店舗名リンク化。
+
+## 参照
+
+- GitHub Issue: #138
+- 変更対象:
+  - `apps/web/src/lib/events.ts` — `PublicEventItem` 型 / `searchPublicEvents`
+  - `apps/web/src/app/[locale]/events/events-list.tsx`
+
+## 実装方針
+
+### 1. `PublicEventItem` に `orgSlug` を追加
+
+`apps/web/src/lib/events.ts`:
+- `PublicEventItem` 型に `orgSlug: string | null` を追加
+- `searchPublicEvents` の SELECT に `orgSlug: organizations.slug` を追加
+- 戻り値マッピングに `orgSlug: row.orgSlug ?? null` を追加
+
+### 2. EventsList カードの店舗名をリンク化
+
+`apps/web/src/app/[locale]/events/events-list.tsx`:
+
+カード全体が `<Link href="/events/[id]">` で囲まれているため、
+店舗名リンクは `onClick={e => e.preventDefault()}` ではなく、
+**カード外側の `<Link>` を `<div>` に変更し、タイトルクリックでイベント詳細へ遷移する構造**に変更する。
+
+具体的には：
+- 外側の `<Link>` → `<div>` に変更（`href` 削除、`group` クラスは維持）
+- タイトル `<p>` → `<Link href="/events/[id]">` に変更
+- 店舗名 `<p>` → `orgSlug` がある場合 `<Link href="/stores/[slug]">` に変更
+
+```tsx
+// 外側: Link → div
+<div key={event.id} className="group flex flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:bg-muted/50">
+
+  {/* サムネイルもイベント詳細へのリンクに */}
+  <Link href={`/${locale}/events/${event.id}`} className="relative aspect-video ...">
+    ...
+  </Link>
+
+  <div className="flex flex-1 flex-col gap-2 p-4">
+    {/* タイトル → イベント詳細リンク */}
+    <Link href={`/${locale}/events/${event.id}`} className="line-clamp-2 font-medium leading-snug hover:underline">
+      {event.title ?? "—"}
+    </Link>
+
+    <div className="space-y-0.5 text-xs text-muted-foreground">
+      {/* 店舗名 → 店舗詳細リンク（orgSlug がある場合のみ） */}
+      {event.orgSlug ? (
+        <Link href={`/${locale}/stores/${event.orgSlug}`} className="truncate block hover:underline hover:text-foreground">
+          {event.orgName}
+        </Link>
+      ) : (
+        <p className="truncate">{event.orgName}</p>
+      )}
+      {event.nearestStation && (
+        <p className="truncate">{event.nearestStation}</p>
+      )}
+    </div>
+    ...
+  </div>
+</div>
+```
+
+## 実装ステップ
+
+1. `apps/web/src/lib/events.ts`
+   - `PublicEventItem` 型に `orgSlug: string | null` を追加
+   - `searchPublicEvents` の SELECT に `orgSlug: organizations.slug` を追加
+   - 戻り値マッピングに `orgSlug: row.orgSlug ?? null` を追加
+
+2. `apps/web/src/app/[locale]/events/events-list.tsx`
+   - 外側 `<Link>` を `<div>` に変更
+   - サムネイルとタイトルを個別の `<Link>` に変更
+   - 店舗名を条件付き `<Link>` に変更
+
+## 受け入れ条件
+
+- [ ] イベント一覧カードの店舗名が `/stores/[slug]` へのリンクになっている
+- [ ] カードのサムネイル・タイトルクリックでイベント詳細へ遷移する
+- [ ] `orgSlug` が null の場合は店舗名がテキストのまま
+- [ ] TypeScript エラーなし
+
+## 影響範囲
+
+- `apps/web/src/lib/events.ts`（型・クエリ変更）
+- `apps/web/src/app/[locale]/events/events-list.tsx`
+- 翻訳キー追加なし

--- a/apps/web/src/app/[locale]/events/events-list.tsx
+++ b/apps/web/src/app/[locale]/events/events-list.tsx
@@ -93,13 +93,12 @@ export function EventsList({ initialEvents, initialHasNext, area, line }: Props)
                 : t("seats_remaining", { count: event.maxParticipants - event.participantCount });
 
           return (
-            <Link
+            <div
               key={event.id}
-              href={`/${locale}/events/${event.id}`}
               className="group flex flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:bg-muted/50"
             >
               {/* サムネイル */}
-              <div className="relative aspect-video w-full overflow-hidden bg-muted">
+              <Link href={`/${locale}/events/${event.id}`} className="relative aspect-video w-full overflow-hidden bg-muted block">
                 {event.thumbnailUrl ? (
                   <Image
                     src={event.thumbnailUrl}
@@ -131,16 +130,28 @@ export function EventsList({ initialEvents, initialHasNext, area, line }: Props)
                     </svg>
                   </div>
                 )}
-              </div>
+              </Link>
 
               {/* カード本文 */}
               <div className="flex flex-1 flex-col gap-2 p-4">
-                <p className="line-clamp-2 font-medium leading-snug">
+                <Link
+                  href={`/${locale}/events/${event.id}`}
+                  className="line-clamp-2 font-medium leading-snug hover:underline"
+                >
                   {event.title ?? "—"}
-                </p>
+                </Link>
 
                 <div className="space-y-0.5 text-xs text-muted-foreground">
-                  <p className="truncate">{event.orgName}</p>
+                  {event.orgSlug ? (
+                    <Link
+                      href={`/${locale}/stores/${event.orgSlug}`}
+                      className="truncate block hover:underline hover:text-foreground"
+                    >
+                      {event.orgName}
+                    </Link>
+                  ) : (
+                    <p className="truncate">{event.orgName}</p>
+                  )}
                   {event.nearestStation && (
                     <p className="truncate">{event.nearestStation}</p>
                   )}
@@ -156,7 +167,7 @@ export function EventsList({ initialEvents, initialHasNext, area, line }: Props)
                   )}
                 </div>
               </div>
-            </Link>
+            </div>
           );
         })}
       </div>

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -556,6 +556,7 @@ export type PublicEventItem = {
   endAt: string | null;
   orgId: string;
   orgName: string;
+  orgSlug: string | null;
   orgAddress: string | null;
   orgPrefecture: string | null;
   nearestStation: string | null;
@@ -635,6 +636,7 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
       endAt: events.endAt,
       orgId: events.orgId,
       orgName: organizations.name,
+      orgSlug: organizations.slug,
       orgAddress: organizations.address,
       orgPrefecture: organizations.prefecture,
       nearestStation: events.nearestStation,
@@ -657,6 +659,7 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
     endAt: row.endAt?.toISOString() ?? null,
     orgId: row.orgId,
     orgName: row.orgName,
+    orgSlug: row.orgSlug ?? null,
     orgAddress: row.orgAddress,
     orgPrefecture: row.orgPrefecture,
     nearestStation: row.nearestStation,


### PR DESCRIPTION
## 概要

closes #138

イベント一覧（/events）のカードに表示されている店舗名を店舗詳細ページへのリンクに変更。

## 変更内容

- `PublicEventItem` 型に `orgSlug: string | null` を追加
- `searchPublicEvents` の SELECT・戻り値マッピングに `orgSlug` を追加
- `EventsList` カードの構造を変更
  - 外側の `<Link>` を `<div>` に変更（ネストした `<a>` を避けるため）
  - サムネイル・タイトルを個別の `<Link href="/events/[id]">` に変更
  - 店舗名を `orgSlug` がある場合 `<Link href="/stores/[slug]">` に変更、ない場合はテキスト

## 確認事項

- [x] TypeScript エラーなし（`tsc --noEmit` 通過）
- [x] イベント一覧カードの店舗名がリンクになっている
- [x] サムネイル・タイトルクリックでイベント詳細へ遷移
- [x] `orgSlug` が null の場合はテキスト表示にフォールバック
- [x] `<a>` のネストなし