### PR TITLE
ci: lint・typecheck・脆弱性診断ワークフローを追加 (#79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  lint:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @e-be/db build
+      - run: pnpm --filter web lint
+      - run: pnpm --filter web exec tsc --noEmit
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level=high

--- a/apps/web/src/components/ui/date-time-picker.tsx
+++ b/apps/web/src/components/ui/date-time-picker.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { format, parseISO, isValid, setHours, setMinutes, startOfMinute } from "date-fns";
-import { ja, enUS } from "date-fns/locale";
+import { ja, enUS, type Locale } from "date-fns/locale";
 import { Calendar as CalendarIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -31,7 +31,7 @@ interface DateTimePickerProps {
   locale?: string;
 }
 
-const locales: Record<string, any> = {
+const locales: Record<string, Locale> = {
   ja: ja,
   en: enUS,
 };


### PR DESCRIPTION
## 概要
Issue #79 の対応。CI/CDワークフローを新規追加。

## 変更内容
- `.github/workflows/ci.yml` 新規作成
  - **lint job**: `@e-be/db` ビルド → `pnpm --filter web lint`（エラーのみfail）
  - **typecheck job**: `pnpm --filter web exec tsc --noEmit`
  - **audit job**: `pnpm audit --audit-level=high`（high以上の脆弱性でfail）
  - トリガー: `apps/**` / `packages/**` / `pnpm-lock.yaml` の変更時
- `date-time-picker.tsx`: `any` → `Locale` 型に修正（既存lintエラー解消）

Closes #79