### PR TITLE
feat: イベント詳細ページに主催者向けSNS投稿アシスト機能を追加（Gemini API）

### DIFF
--- a/.claude/steering/issue-140-sns-assist-gemini.md
+++ b/.claude/steering/issue-140-sns-assist-gemini.md
@@ -1,0 +1,158 @@
+# Issue #140: feat: イベント詳細ページに主催者向けSNS投稿アシスト機能を追加（Gemini API）
+
+## 背景
+
+イベント詳細ページ（`/dashboard/event/[eventId]`）に、主催者のみ表示される
+「SNS投稿を作成」セクションを追加する。
+Gemini API でイベント情報から X 投稿文言と画像生成プロンプトを生成する。
+
+## 参照
+
+- GitHub Issue: #140
+- 変更対象:
+  - `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+  - `apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx`（新規）
+  - `apps/web/src/lib/actions/sns-assist.ts`（新規）
+  - `apps/web/messages/ja.json` / `en.json`
+
+## 主催者判定
+
+`event.organizerUserId === user.id` で判定する。
+`EventDetail` 型に `organizerUserId` は既に含まれている。
+`page.tsx` では `user` オブジェクトが取得済みのため、そのまま比較可能。
+
+## 実装方針
+
+### Server Action (`apps/web/src/lib/actions/sns-assist.ts`)
+
+```ts
+"use server";
+// Gemini API を呼び出し、X投稿文言と画像生成プロンプトを返す
+export async function generateSnsContent(eventId: string): Promise<{
+  xPost: string;
+  imagePrompt: string;
+} | { error: string }>
+```
+
+- `GEMINI_API_KEY` 環境変数から API キーを取得
+- キーがない場合はエラーを返す
+- `@google/generative-ai` パッケージを使用
+- モデル: `gemini-1.5-flash`
+- イベント情報（タイトル・日時・場所・説明）を元にプロンプトを構築
+- 1回のリクエストで X 投稿文言と画像生成プロンプトの両方を生成（JSON レスポンス）
+
+プロンプト例:
+```
+以下のイベント情報を元に、2つのコンテンツを JSON 形式で生成してください。
+
+イベント情報:
+- タイトル: {title}
+- 日時: {startAt}
+- 場所: {location}
+- 説明: {description}
+
+出力形式（JSON のみ）:
+{
+  "xPost": "X（Twitter）投稿文言（140文字以内、ハッシュタグ含む）",
+  "imagePrompt": "SNS画像生成用英語プロンプト（Midjourney/DALL-E向け）"
+}
+```
+
+### Client Component (`apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx`)
+
+```tsx
+"use client";
+// 「生成する」ボタン → Server Action 呼び出し → 結果表示 + コピーボタン
+export function SnsAssist({ eventId }: { eventId: string })
+```
+
+- 「生成する」ボタン押下で `generateSnsContent(eventId)` を呼び出し
+- ローディング中はスピナー表示
+- 結果表示エリア（X投稿文言 / 画像生成プロンプト）
+- 各結果に「コピー」ボタン（`navigator.clipboard.writeText`）
+- エラー時はエラーメッセージを表示
+
+### ページへの組み込み (`page.tsx`)
+
+```tsx
+{event.organizerUserId === user.id && (
+  <SnsAssist eventId={event.id} />
+)}
+```
+
+## 実装ステップ
+
+1. `apps/web/package.json` に `@google/generative-ai` を追加
+   ```bash
+   pnpm --filter web add @google/generative-ai
+   ```
+
+2. `apps/web/src/lib/actions/sns-assist.ts` を新規作成
+   - Gemini API 呼び出し Server Action
+
+3. `apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx` を新規作成
+   - Client Component（ボタン・ローディング・結果表示・コピーボタン）
+
+4. `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx` を更新
+   - 主催者判定して `<SnsAssist>` を表示
+
+5. `apps/web/messages/ja.json` / `en.json` に翻訳キーを追加
+
+6. `.env.local` に `GEMINI_API_KEY=` を追記（値はユーザーが設定）
+
+## 翻訳キー（`event_detail` 名前空間に追加）
+
+```json
+{
+  "sns_assist_title": "SNS投稿を作成",
+  "sns_assist_generate": "生成する",
+  "sns_assist_generating": "生成中...",
+  "sns_assist_x_post": "X（Twitter）投稿文言",
+  "sns_assist_image_prompt": "画像生成プロンプト",
+  "sns_assist_copy": "コピー",
+  "sns_assist_copied": "コピーしました",
+  "sns_assist_error": "生成に失敗しました。再度お試しください。"
+}
+```
+
+## フォールバック策
+
+| 状況 | 挙動 |
+|------|------|
+| `GEMINI_API_KEY` 未設定 | セクション自体を非表示にする（Server Component で判定） |
+| API 呼び出しエラー（ネットワーク・レート制限等） | エラーメッセージを表示し「再試行」ボタンを表示 |
+| レスポンスが JSON パース失敗 | エラーメッセージを表示 |
+
+`GEMINI_API_KEY` 未設定の場合はセクションごと非表示にすることで、
+キーを持っていないユーザーには何も見えず、UX を壊さない。
+
+```tsx
+// page.tsx（Server Component）
+const canUseAI = !!process.env.GEMINI_API_KEY;
+
+{canUseAI && event.organizerUserId === user.id && (
+  <SnsAssist eventId={event.id} />
+)}
+```
+
+
+
+- `GEMINI_API_KEY` — Google AI Studio で発行した API キー
+  - ローカル: `apps/web/.env.local` に追記
+  - 本番: Vercel Environment Variables に登録
+
+## 受け入れ条件
+
+- [ ] 主催者のみ「SNS投稿を作成」セクションが表示される
+- [ ] 「生成する」ボタンで X 投稿文言と画像生成プロンプトが生成される
+- [ ] 各結果にコピーボタンがある
+- [ ] `GEMINI_API_KEY` が未設定の場合はエラーメッセージを表示
+- [ ] API キーはコードに直書きしない
+
+## 影響範囲
+
+- `apps/web/package.json`（`@google/generative-ai` 追加）
+- `apps/web/src/lib/actions/sns-assist.ts`（新規）
+- `apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx`（新規）
+- `apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx`
+- `apps/web/messages/ja.json` / `en.json`

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -354,7 +354,15 @@
     "toast_error": "Something went wrong. Please try again",
     "organizer_x": "Organizer X (Twitter)",
     "back_to_events": "Back to Events",
-    "sign_in_to_join": "Sign in to Join"
+    "sign_in_to_join": "Sign in to Join",
+    "sns_assist_title": "Create SNS Post",
+    "sns_assist_generate": "Generate",
+    "sns_assist_generating": "Generating...",
+    "sns_assist_x_post": "X (Twitter) Post",
+    "sns_assist_image_prompt": "Image Generation Prompt",
+    "sns_assist_copy": "Copy",
+    "sns_assist_copied": "Copied!",
+    "sns_assist_error": "Generation failed. Please try again."
   },
   "privacy": {
     "title": "Privacy Policy",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -354,7 +354,15 @@
     "toast_error": "エラーが発生しました。もう一度お試しください",
     "organizer_x": "主催者 X (Twitter)",
     "back_to_events": "イベント一覧へ戻る",
-    "sign_in_to_join": "サインインして参加する"
+    "sign_in_to_join": "サインインして参加する",
+    "sns_assist_title": "SNS投稿を作成",
+    "sns_assist_generate": "生成する",
+    "sns_assist_generating": "生成中...",
+    "sns_assist_x_post": "X（Twitter）投稿文言",
+    "sns_assist_image_prompt": "画像生成プロンプト",
+    "sns_assist_copy": "コピー",
+    "sns_assist_copied": "コピーしました",
+    "sns_assist_error": "生成に失敗しました。再度お試しください。"
   },
   "privacy": {
     "title": "プライバシーポリシー",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@e-be/db": "workspace:*",
-    "postgres": "^3.4.4",
+    "@google/generative-ai": "^0.24.1",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.3",
     "class-variance-authority": "^0.7.1",
@@ -25,6 +25,7 @@
     "lucide-react": "^0.577.0",
     "next": "16.2.0",
     "next-intl": "^4.8.3",
+    "postgres": "^3.4.4",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { ParticipationButton } from "./participation-button";
+import { SnsAssist } from "./sns-assist";
 
 type Props = {
   params: Promise<{ eventId: string }>;
@@ -247,6 +248,11 @@ export default async function EventDetailPage({ params }: Props) {
             />
           </CardContent>
         </Card>
+
+        {/* SNS投稿アシスト（主催者かつ GEMINI_API_KEY 設定済みの場合のみ） */}
+        {!!process.env.GEMINI_API_KEY && event.organizerUserId === user.id && (
+          <SnsAssist eventId={event.id} />
+        )}
 
       </div>
     </main>

--- a/apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx
+++ b/apps/web/src/app/[locale]/dashboard/event/[eventId]/sns-assist.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { generateSnsContent } from "@/lib/actions/sns-assist";
+
+interface Props {
+  eventId: string;
+}
+
+export function SnsAssist({ eventId }: Props) {
+  const t = useTranslations("event_detail");
+  const [isLoading, setIsLoading] = useState(false);
+  const [xPost, setXPost] = useState<string | null>(null);
+  const [imagePrompt, setImagePrompt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    setIsLoading(true);
+    setError(null);
+    const result = await generateSnsContent(eventId);
+    if (result.ok) {
+      setXPost(result.data.xPost);
+      setImagePrompt(result.data.imagePrompt);
+    } else {
+      setError(t("sns_assist_error"));
+    }
+    setIsLoading(false);
+  }
+
+  async function handleCopy(text: string, key: string) {
+    await navigator.clipboard.writeText(text);
+    setCopiedKey(key);
+    setTimeout(() => setCopiedKey(null), 2000);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("sns_assist_title")}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button onClick={handleGenerate} disabled={isLoading} className="w-full sm:w-auto">
+          {isLoading ? (
+            <span className="flex items-center gap-2">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              {t("sns_assist_generating")}
+            </span>
+          ) : (
+            t("sns_assist_generate")
+          )}
+        </Button>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        {xPost && (
+          <div className="space-y-1.5">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+              {t("sns_assist_x_post")}
+            </p>
+            <div className="rounded-md border bg-muted/40 p-3 text-sm whitespace-pre-wrap">{xPost}</div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(xPost, "xPost")}
+            >
+              {copiedKey === "xPost" ? t("sns_assist_copied") : t("sns_assist_copy")}
+            </Button>
+          </div>
+        )}
+
+        {imagePrompt && (
+          <div className="space-y-1.5">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+              {t("sns_assist_image_prompt")}
+            </p>
+            <div className="rounded-md border bg-muted/40 p-3 text-sm whitespace-pre-wrap font-mono">{imagePrompt}</div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(imagePrompt, "imagePrompt")}
+            >
+              {copiedKey === "imagePrompt" ? t("sns_assist_copied") : t("sns_assist_copy")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/actions/sns-assist.ts
+++ b/apps/web/src/lib/actions/sns-assist.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { getEventDetail } from "@/lib/events";
+import { getUser } from "@/lib/auth";
+
+type SnsContent = {
+  xPost: string;
+  imagePrompt: string;
+};
+
+type Result = { ok: true; data: SnsContent } | { ok: false; error: string };
+
+export async function generateSnsContent(eventId: string): Promise<Result> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) return { ok: false, error: "API key not configured" };
+
+  const user = await getUser();
+  if (!user) return { ok: false, error: "Unauthorized" };
+
+  const event = await getEventDetail(eventId, user.id);
+  if (!event) return { ok: false, error: "Event not found" };
+  if (event.organizerUserId !== user.id) return { ok: false, error: "Forbidden" };
+
+  const prompt = `以下のイベント情報を元に、2つのコンテンツをJSON形式で生成してください。
+
+イベント情報:
+- タイトル: ${event.title ?? "未設定"}
+- 日時: ${event.startAt ? new Date(event.startAt).toLocaleString("ja-JP") : "未設定"}
+- 場所: ${event.location ?? "未設定"}
+- 説明: ${event.description ?? "なし"}
+
+出力形式（JSONのみ、説明文不要）:
+{
+  "xPost": "X（Twitter）投稿文言（140文字以内、ハッシュタグ含む、日本語）",
+  "imagePrompt": "SNS画像生成用英語プロンプト（Midjourney/DALL-E向け、英語）"
+}`;
+
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text().trim();
+
+    // ```json ... ``` のコードブロックを除去
+    const jsonText = text.replace(/^```json\s*/i, "").replace(/\s*```$/, "").trim();
+    const parsed = JSON.parse(jsonText) as SnsContent;
+
+    if (!parsed.xPost || !parsed.imagePrompt) {
+      return { ok: false, error: "Invalid response format" };
+    }
+
+    return { ok: true, data: parsed };
+  } catch (e) {
+    console.error("Gemini API error:", e);
+    return { ok: false, error: "Generation failed. Please try again." };
+  }
+}


### PR DESCRIPTION
## 概要

closes #140

イベント詳細ページに、主催者のみ表示される「SNS投稿を作成」セクションを追加。
Gemini API（gemini-1.5-flash）でX投稿文言と画像生成プロンプトを生成する。

## 変更内容

- `@google/generative-ai` パッケージを追加
- Server Action `generateSnsContent` を新規作成（Gemini API 呼び出し）
- Client Component `SnsAssist` を新規作成（生成ボタン・結果表示・コピーボタン）
- イベント詳細ページに `SnsAssist` を組み込み（主催者かつ API キー設定済みの場合のみ表示）
- ja.json / en.json に翻訳キーを追加

## フォールバック

| 状況 | 挙動 |
|------|------|
| `GEMINI_API_KEY` 未設定 | セクション自体を非表示 |
| API エラー | エラーメッセージ表示 |
| JSON パース失敗 | エラーメッセージ表示 |

## 動作確認に必要な設定

`apps/web/.env.local` に以下を追加:
```
GEMINI_API_KEY=your_api_key_here
```

## 確認事項

- [x] TypeScript エラーなし
- [x] 主催者のみセクションが表示される
- [x] API キー未設定時はセクション非表示
- [x] ja/en 翻訳キー追加済み