### PR TITLE
design: リキッドグラスUIデザインへのリニューアル（青・紫・ティール）

### DIFF
--- a/.claude/steering/issue-146-liquid-glass-design.md
+++ b/.claude/steering/issue-146-liquid-glass-design.md
@@ -1,0 +1,150 @@
+# Issue #146: design: リキッドグラスUIデザインへのリニューアル
+
+## 背景
+
+現在のデザインが白黒ベースでシンプルすぎる。
+青・紫・ティール系カラーを軸に、リキッドグラス質感を全体に適用する。
+
+## 参照
+
+- GitHub Issue: #146
+- 変更対象: `apps/web/src/app/globals.css`（メイン）
+- 参考: `apps/web/src/components/ui/card.tsx`（glass variant 確認）
+
+## 現状の把握
+
+- `brand` = アンバー/黄橙系 `oklch(0.769 0.188 70.08)` → **青系に変更**
+- `feature` = バイオレット系 `oklch(0.606 0.213 293.74)` → **維持**
+- `.glass` ユーティリティは既存だが弱い → **強化**
+- `primary` = 黒系 → **青系グラデーションに変更**
+
+## カラー変更方針
+
+### `brand` を青系に変更
+
+```css
+/* ライト */
+--brand: oklch(0.55 0.22 250);        /* 鮮やかな青 */
+--brand-foreground: oklch(0.985 0 0); /* 白 */
+
+/* ダーク */
+--brand: oklch(0.65 0.20 250);
+--brand-foreground: oklch(0.985 0 0);
+```
+
+### `teal`（ティール）カラートークンを新規追加
+
+```css
+/* @theme inline に追加 */
+--color-teal: var(--teal);
+--color-teal-foreground: var(--teal-foreground);
+
+/* :root */
+--teal: oklch(0.60 0.14 185);         /* エメラルド/ティール */
+--teal-foreground: oklch(0.985 0 0);
+
+/* .dark */
+--teal: oklch(0.68 0.13 185);
+--teal-foreground: oklch(0.985 0 0);
+```
+
+### `primary` を青系に変更（ライト）
+
+```css
+--primary: oklch(0.55 0.22 250);      /* brand と同じ青 */
+--primary-foreground: oklch(0.985 0 0);
+--ring: oklch(0.55 0.22 250);
+```
+
+## リキッドグラス強化
+
+### `.glass` ユーティリティを強化
+
+```css
+@layer utilities {
+  .glass {
+    background: oklch(1 0 0 / 0.72);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid oklch(1 0 0 / 0.35);
+    box-shadow: 0 8px 32px oklch(0.55 0.22 250 / 0.08),
+                inset 0 1px 0 oklch(1 0 0 / 0.4);
+  }
+  .dark .glass {
+    background: oklch(0.18 0.02 250 / 0.72);
+    border: 1px solid oklch(1 0 0 / 0.12);
+    box-shadow: 0 8px 32px oklch(0 0 0 / 0.3),
+                inset 0 1px 0 oklch(1 0 0 / 0.08);
+  }
+}
+```
+
+### ページ背景グラデーション
+
+`body` にグラデーション背景を追加：
+
+```css
+body {
+  @apply text-foreground;
+  background: linear-gradient(
+    135deg,
+    oklch(0.97 0.02 250) 0%,
+    oklch(0.98 0.01 293) 50%,
+    oklch(0.97 0.02 185) 100%
+  );
+  min-height: 100vh;
+}
+.dark body {
+  background: linear-gradient(
+    135deg,
+    oklch(0.12 0.03 250) 0%,
+    oklch(0.13 0.02 293) 50%,
+    oklch(0.12 0.02 185) 100%
+  );
+}
+```
+
+## ヘッダーのガラス強化
+
+`AppHeader`・`PublicHeader`・`NavBar` の既存 `bg-background/80 backdrop-blur-md` を
+`glass` クラスに置き換える。
+
+```tsx
+// before
+className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur-md"
+
+// after
+className="sticky top-0 z-40 border-b glass"
+```
+
+対象ファイル:
+- `apps/web/src/components/layout/app-header.tsx`
+- `apps/web/src/components/layout/public-header.tsx`
+- `apps/web/src/components/lp/nav-bar.tsx`
+
+## 実装ステップ
+
+1. `globals.css` を更新
+   - `brand` を青系に変更（ライト・ダーク両方）
+   - `primary` / `ring` を青系に変更
+   - `teal` カラートークンを追加（`@theme inline` + `:root` + `.dark`）
+   - `.glass` ユーティリティを強化
+   - `body` 背景グラデーションを追加
+
+2. ヘッダー3ファイルの `bg-background/80 backdrop-blur-md` を `glass` に変更
+
+## 受け入れ条件
+
+- [ ] `brand` が青系になっている
+- [ ] `teal` カラートークンが追加されている
+- [ ] ページ背景に青〜紫〜ティールの薄いグラデーションがある
+- [ ] ヘッダーがリキッドグラス質感になっている
+- [ ] ダークモードで崩れない
+- [ ] TypeScript エラーなし
+
+## 影響範囲
+
+- `apps/web/src/app/globals.css`
+- `apps/web/src/components/layout/app-header.tsx`
+- `apps/web/src/components/layout/public-header.tsx`
+- `apps/web/src/components/lp/nav-bar.tsx`

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -13,6 +13,8 @@
   --color-brand-foreground: var(--brand-foreground);
   --color-feature: var(--feature);
   --color-feature-foreground: var(--feature-foreground);
+  --color-teal: var(--teal);
+  --color-teal-foreground: var(--teal-foreground);
   --color-amber: var(--amber);
   --color-amber-foreground: var(--amber-foreground);
   --color-violet: var(--violet);
@@ -62,7 +64,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --primary: oklch(0.55 0.22 250);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -73,16 +75,18 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.55 0.22 250);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --brand: oklch(0.769 0.188 70.08);
-  --brand-foreground: oklch(0.2 0.05 70);
+  --brand: oklch(0.55 0.22 250);
+  --brand-foreground: oklch(0.985 0 0);
   --feature: oklch(0.606 0.213 293.74);
   --feature-foreground: oklch(0.985 0 0);
+  --teal: oklch(0.60 0.14 185);
+  --teal-foreground: oklch(0.985 0 0);
   --amber: oklch(0.769 0.188 70.08);
   --amber-foreground: oklch(0.2 0.05 70);
   --violet: oklch(0.606 0.213 293.74);
@@ -105,8 +109,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.65 0.20 250);
+  --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -116,16 +120,18 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.65 0.20 250);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --brand: oklch(0.75 0.17 68);
-  --brand-foreground: oklch(0.15 0.04 68);
+  --brand: oklch(0.65 0.20 250);
+  --brand-foreground: oklch(0.985 0 0);
   --feature: oklch(0.65 0.22 293);
   --feature-foreground: oklch(0.985 0 0);
+  --teal: oklch(0.68 0.13 185);
+  --teal-foreground: oklch(0.985 0 0);
   --amber: oklch(0.75 0.17 68);
   --amber-foreground: oklch(0.15 0.04 68);
   --violet: oklch(0.65 0.22 293);
@@ -142,14 +148,18 @@
 
 @layer utilities {
   .glass {
-    background: oklch(1 0 0 / 0.65);
-    backdrop-filter: blur(12px) saturate(1.5);
-    -webkit-backdrop-filter: blur(12px) saturate(1.5);
-    border: 1px solid oklch(1 0 0 / 0.3);
+    background: oklch(1 0 0 / 0.72);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid oklch(1 0 0 / 0.35);
+    box-shadow: 0 8px 32px oklch(0.55 0.22 250 / 0.08),
+                inset 0 1px 0 oklch(1 0 0 / 0.4);
   }
   .dark .glass {
-    background: oklch(0.2 0 0 / 0.65);
-    border: 1px solid oklch(1 0 0 / 0.1);
+    background: oklch(0.18 0.02 250 / 0.72);
+    border: 1px solid oklch(1 0 0 / 0.12);
+    box-shadow: 0 8px 32px oklch(0 0 0 / 0.3),
+                inset 0 1px 0 oklch(1 0 0 / 0.08);
   }
 }
 
@@ -158,7 +168,22 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background: linear-gradient(
+      135deg,
+      oklch(0.97 0.02 250) 0%,
+      oklch(0.98 0.01 293) 50%,
+      oklch(0.97 0.02 185) 100%
+    );
+    min-height: 100vh;
+  }
+  .dark body {
+    background: linear-gradient(
+      135deg,
+      oklch(0.12 0.03 250) 0%,
+      oklch(0.13 0.02 293) 50%,
+      oklch(0.12 0.02 185) 100%
+    );
   }
   html {
     @apply font-sans;

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -15,7 +15,7 @@ export async function AppHeader({ userEmail, userType, locale }: AppHeaderProps)
   const t = await getTranslations("dashboard");
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b glass">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 h-14 md:px-6">
         <Link href={`/${locale}`} className="text-base font-bold tracking-tight">
           {APP_NAME}

--- a/apps/web/src/components/layout/public-header.tsx
+++ b/apps/web/src/components/layout/public-header.tsx
@@ -15,7 +15,7 @@ export async function PublicHeader({ isLoggedIn = false }: { isLoggedIn?: boolea
   ]);
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b glass">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 h-14 md:px-6">
         <Link href={`/${locale}`} className="text-base font-bold tracking-tight">
           {APP_NAME}

--- a/apps/web/src/components/lp/nav-bar.tsx
+++ b/apps/web/src/components/lp/nav-bar.tsx
@@ -31,7 +31,7 @@ export function NavBar({ locale, isLoggedIn, labels }: NavBarProps) {
     <header
       className={cn(
         "fixed left-0 right-0 top-0 z-50 transition-all duration-300",
-        scrolled && "border-b bg-background/95 shadow-sm backdrop-blur-sm"
+        scrolled && "border-b glass shadow-sm"
       )}
     >
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 h-16">


### PR DESCRIPTION
## 概要

closes #146

白黒ベースのデザインを青・紫・ティール系カラー＋リキッドグラス質感にリニューアル。

## 変更内容

### カラー変更
- `brand` を黄橙系 → **青系**（`oklch(0.55 0.22 250)`）に変更
- `primary` / `ring` も青系に統一
- `teal` カラートークンを新規追加（エメラルド/ティール系）

### リキッドグラス強化
- `.glass` ユーティリティを強化（blur 20px・saturate 180%・box-shadow追加）
- `body` 背景に青〜紫〜ティールの薄いグラデーションを追加
- ヘッダー3ファイル（AppHeader・PublicHeader・NavBar）を `glass` クラスに変更

## 確認事項

- [x] TypeScript エラーなし
- [x] ライト・ダークモード両対応
- [x] `teal` トークン追加済み