### PR TITLE
fix: IME composition中のEnterキーでチャットが送信される不具合を修正

### DIFF
--- a/apps/web/src/components/ai-chat/chat-widget.tsx
+++ b/apps/web/src/components/ai-chat/chat-widget.tsx
@@ -40,7 +40,7 @@ export function ChatWidget() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSend();
     }


### PR DESCRIPTION
## 概要

AIチャットウィジェットで日本語(全角)入力中、IME変換確定のEnterキーでメッセージが誤送信される不具合を修正。

## 変更内容

- `handleKeyDown` に `e.nativeEvent.isComposing` チェックを追加
- IME コンポジション中（変換確定前）の Enter キーイベントを無視
- 変換確定後の Enter で正常に送信される
- Shift+Enter の改行機能は従来通り動作

## テスト方法

- [ ] 日本語入力で IME 変換中に Enter を押してもメッセージが送信されないこと
- [ ] 変換確定後に Enter を押すとメッセージが送信されること
- [ ] Shift+Enter で改行が挿入されること

## 関連 Issue

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)