### PR TITLE
feat: AI agent event creation with tool calling (#162)

### DIFF
--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -2,6 +2,10 @@ import { streamText, convertToModelMessages, stepCountIs, tool } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { z } from "zod";
 import type { UIMessage } from "ai";
+import { getDbUser, getUserType } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { events, organizations, barHostPermissions } from "@e-be/db/schema";
+import { eq, and, isNull } from "drizzle-orm";
 
 const google = createGoogleGenerativeAI({
   apiKey: process.env.GEMINI_API_KEY ?? "",
@@ -11,12 +15,21 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
   const modelMessages = await convertToModelMessages(messages);
 
+  const dbUser = await getDbUser();
+
   const result = streamText({
     model: google("gemini-2.5-flash"),
     system: `あなたは e-be のAIアシスタントです。
 e-be はイベント主催者・店舗向けのイベント運営・分析プラットフォームです。
 ユーザーのイベント企画・集客・運営に関する質問に日本語で丁寧に答えてください。
-必要に応じてツールを使い、ステップバイステップで考えて回答してください。`,
+必要に応じてツールを使い、ステップバイステップで考えて回答してください。
+
+イベント作成機能について:
+- createEvent ツールを使ってイベントの下書きを作成できます
+- 作成前に必ず以下の情報を会話で確認してください: バー（listBars で一覧取得）、タイトル（最大100文字）、説明（最大2000文字）
+- 日時（startAt・endAt）が分かれば設定してください（なくても下書き作成は可能です）
+- 作成されるのは「下書き」状態です。申請・公開は管理画面から行う必要があります
+- 未ログインの場合はイベントを作成できません`,
     messages: modelMessages,
     tools: {
       writePlan: tool({
@@ -44,8 +57,125 @@ e-be はイベント主催者・店舗向けのイベント運営・分析プラ
           timezone: "Asia/Tokyo",
         }),
       }),
+      listBars: tool({
+        description:
+          "ユーザーがイベントを主催できるバー（会場）の一覧を取得する。イベント作成前にバーを選んでもらうために使う。",
+        inputSchema: z.object({}),
+        execute: async () => {
+          if (!dbUser) return { error: "unauthorized", bars: [] };
+
+          const permitted = await db
+            .select({ id: organizations.id, name: organizations.name })
+            .from(barHostPermissions)
+            .innerJoin(
+              organizations,
+              eq(barHostPermissions.barId, organizations.id)
+            )
+            .where(
+              and(
+                eq(barHostPermissions.userId, dbUser.id),
+                isNull(barHostPermissions.revokedAt),
+                isNull(barHostPermissions.deletedAt),
+                isNull(organizations.deletedAt)
+              )
+            );
+
+          if (permitted.length > 0) {
+            return { bars: permitted };
+          }
+
+          // 許可済みバーがない場合は全バー一覧を返す（申請可能な候補として）
+          const all = await db
+            .select({ id: organizations.id, name: organizations.name })
+            .from(organizations)
+            .where(isNull(organizations.deletedAt))
+            .limit(20);
+
+          return { bars: all };
+        },
+      }),
+      createEvent: tool({
+        description:
+          "イベントの下書きを作成する。バー・タイトル・説明が揃った段階で呼び出す。",
+        inputSchema: z.object({
+          orgId: z.string().describe("バーのID（listBars で取得した id）"),
+          title: z.string().max(100).describe("イベントタイトル（最大100文字）"),
+          description: z
+            .string()
+            .max(2000)
+            .describe("イベント説明（最大2000文字）"),
+          startAt: z
+            .string()
+            .optional()
+            .describe("開催開始日時（ISO 8601形式、任意）"),
+          endAt: z
+            .string()
+            .optional()
+            .describe("開催終了日時（ISO 8601形式、任意）"),
+          maxParticipants: z
+            .number()
+            .int()
+            .min(1)
+            .max(500)
+            .optional()
+            .describe("定員（1〜500、任意）"),
+          chargeAmount: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("チャージ料（円、0=無料、任意）"),
+        }),
+        execute: async ({
+          orgId,
+          title,
+          description,
+          startAt,
+          endAt,
+          maxParticipants,
+          chargeAmount,
+        }) => {
+          if (!dbUser) return { error: "unauthorized" };
+
+          const userType = await getUserType(dbUser.id);
+          if (userType !== "user") return { error: "forbidden" };
+
+          if (!/^[0-9a-f-]{36}$/.test(orgId)) return { error: "invalid_org" };
+          if (!title.trim() || title.length > 100)
+            return { error: "invalid_title" };
+          if (!description.trim() || description.length > 2000)
+            return { error: "invalid_description" };
+
+          const startAtDate = startAt ? new Date(startAt) : undefined;
+          const endAtDate = endAt ? new Date(endAt) : undefined;
+
+          if (startAtDate && isNaN(startAtDate.getTime()))
+            return { error: "invalid_start_at" };
+          if (endAtDate && isNaN(endAtDate.getTime()))
+            return { error: "invalid_end_at" };
+          if (startAtDate && endAtDate && endAtDate <= startAtDate)
+            return { error: "invalid_date_range" };
+
+          const [event] = await db
+            .insert(events)
+            .values({
+              orgId,
+              userId: dbUser.id,
+              status: "draft",
+              title: title.trim(),
+              description: description.trim(),
+              startAt: startAtDate ?? null,
+              endAt: endAtDate ?? null,
+              maxParticipants: maxParticipants ?? null,
+              chargeAmount: chargeAmount ?? null,
+            })
+            .returning({ id: events.id, title: events.title });
+
+          return { ok: true, eventId: event.id, title: event.title, status: "draft" };
+        },
+      }),
     },
-    stopWhen: stepCountIs(5),
+    stopWhen: stepCountIs(10),
   });
 
   return result.toUIMessageStreamResponse();

--- a/apps/web/src/components/ai-chat/chat-widget.tsx
+++ b/apps/web/src/components/ai-chat/chat-widget.tsx
@@ -10,6 +10,9 @@ import {
   User,
   CheckSquare,
   Clock,
+  CalendarPlus,
+  ExternalLink,
+  AlertCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -24,6 +27,10 @@ type ToolGetCurrentDateTimeOutput = {
   datetime: string;
   timezone: string;
 };
+
+type ToolCreateEventOutput =
+  | { ok: true; eventId: string; title: string; status: string }
+  | { error: string };
 
 export function ChatWidget() {
   const [isOpen, setIsOpen] = useState(false);
@@ -204,6 +211,52 @@ export function ChatWidget() {
                         >
                           <Clock className="size-3" />
                           <span>{output.datetime}</span>
+                        </div>
+                      );
+                    }
+
+                    // createEvent ツール
+                    if (
+                      part.type === "tool-createEvent" &&
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      (part as any).state === "output-available"
+                    ) {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      const output = (part as any).output as ToolCreateEventOutput;
+                      if ("error" in output) {
+                        return (
+                          <div
+                            key={i}
+                            className="flex items-center gap-2 rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+                          >
+                            <AlertCircle className="size-4 shrink-0" />
+                            <span>
+                              イベントの作成に失敗しました（{output.error}）
+                            </span>
+                          </div>
+                        );
+                      }
+                      return (
+                        <div
+                          key={i}
+                          className="w-full rounded-2xl rounded-tl-sm border border-green-500/20 bg-green-500/5 px-3 py-2.5 text-sm"
+                        >
+                          <div className="mb-2 flex items-center gap-1.5 font-medium text-green-700 dark:text-green-400">
+                            <CalendarPlus className="size-3.5" />
+                            <span>下書きを作成しました</span>
+                          </div>
+                          <p className="mb-2 text-xs text-muted-foreground line-clamp-2">
+                            {output.title}
+                          </p>
+                          <a
+                            href={`/ja/dashboard/event/${output.eventId}/edit`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                          >
+                            <ExternalLink className="size-3" />
+                            イベント編集画面を開く
+                          </a>
                         </div>
                       );
                     }


### PR DESCRIPTION
## 概要
チャットから直接イベント下書きを作成できる AI Agent 機能を実装。`listBars` と `createEvent` ツールを追加し、会話ベースのイベント作成フローを実現します。

## 変更内容
- `listBars` ツール実装：ユーザーが主催可能なバー一覧を取得
- `createEvent` ツール実装：バリデーション＋DB insert で draft イベント作成
- システムプロンプト更新：ツール説明・確認フロー追記
- チャット UI に `tool-createEvent` 結果カード追加
  - 成功：緑カード + イベント編集ページリンク
  - 失敗：赤エラーカード

## 認証・バリデーション
- `getDbUser()` でセッションユーザーを取得
- `userType === "user"` のチェック（venue_user は作成不可）
- orgId: UUID 形式検証
- title: 最大 100 文字
- description: 最大 2000 文字

## 関連 Issue
Closes #162

## 確認方法
- [x] Playwright で AI chat ウィジェットを検証
  - "イベントを作成したい" で開始
  - AI が listBars ツール呼び出し → バー一覧表示
  - バーとタイトル・説明を指定
  - AI が createEvent ツール呼び出し
  - 結果カード（緑＋リンク）が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)