### PR TITLE
feat: AIチャット — suggest-replies ツール追加（会話中のクイックリプライ候補表示）

### DIFF
--- a/apps/web/src/components/ai-chat/chat-widget.tsx
+++ b/apps/web/src/components/ai-chat/chat-widget.tsx
@@ -24,6 +24,7 @@ import { toolResultRegistry } from "./tool-results";
 import { renderTextWithLinks } from "./render-text";
 import { useTranslations } from "next-intl";
 import { useChatPageContext } from "@/contexts/chat-page-context";
+import { ChatSendProvider } from "@/contexts/chat-send-context";
 import { toast } from "sonner";
 import { MessageResponse } from "@/components/ai-elements/message";
 
@@ -204,8 +205,9 @@ export function ChatWidget() {
           </div>
 
           {/* Messages */}
-          <div className="flex-1 space-y-3 overflow-y-auto p-4">
-            {historyLoading && (
+          <ChatSendProvider value={{ sendMessage, isLoading }}>
+            <div className="flex-1 space-y-3 overflow-y-auto p-4">
+              {historyLoading && (
               <div className="space-y-3">
                 {[1, 2, 3].map((n) => (
                   <div
@@ -400,8 +402,9 @@ export function ChatWidget() {
               </div>
             )}
 
-            <div ref={messagesEndRef} />
-          </div>
+              <div ref={messagesEndRef} />
+            </div>
+          </ChatSendProvider>
 
           {/* Input */}
           <div className="shrink-0 border-t border-white/20 bg-white/5 p-3">

--- a/apps/web/src/components/ai-chat/tool-results/index.tsx
+++ b/apps/web/src/components/ai-chat/tool-results/index.tsx
@@ -4,6 +4,7 @@ import { GetCurrentDateTimeResult } from "./get-current-date-time-result";
 import { CreateEventResult } from "./create-event-result";
 import { UpdateEventResult } from "./update-event-result";
 import { SubmitEventResult } from "./submit-event-result";
+import { SuggestRepliesResult } from "./suggest-replies-result";
 
 // ツール名 → コンポーネント のレジストリ
 // output の型は各コンポーネント側で管理するため unknown で受け取る
@@ -22,6 +23,9 @@ export const toolResultRegistry: Record<
     output: unknown;
   }>,
   "tool-submitEvent": SubmitEventResult as React.ComponentType<{
+    output: unknown;
+  }>,
+  "tool-suggestReplies": SuggestRepliesResult as React.ComponentType<{
     output: unknown;
   }>,
   // tool-listEvents と tool-listBars は中間ツールなので UI 表示なし

--- a/apps/web/src/components/ai-chat/tool-results/suggest-replies-result.tsx
+++ b/apps/web/src/components/ai-chat/tool-results/suggest-replies-result.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useChatSend } from "@/contexts/chat-send-context";
+
+type Output = { replies: string[] };
+type Props = { output: Output };
+
+export function SuggestRepliesResult({ output }: Props) {
+  const { sendMessage, isLoading } = useChatSend();
+
+  return (
+    <div className="flex flex-wrap gap-1.5 py-0.5">
+      {output.replies.map((reply) => (
+        <button
+          key={reply}
+          onClick={() => sendMessage({ text: reply })}
+          disabled={isLoading}
+          className={cn(
+            "rounded-full border border-border/60 bg-background/60 px-3 py-1.5 text-xs text-foreground/80",
+            "transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+            "cursor-pointer"
+          )}
+        >
+          {reply}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/contexts/chat-send-context.tsx
+++ b/apps/web/src/contexts/chat-send-context.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+
+type ChatSendContextValue = {
+  sendMessage: UseChatHelpers["sendMessage"];
+  isLoading: boolean;
+};
+
+const ChatSendContext = createContext<ChatSendContextValue | null>(null);
+
+export const ChatSendProvider = ChatSendContext.Provider;
+
+export function useChatSend() {
+  const ctx = useContext(ChatSendContext);
+  if (!ctx) throw new Error("useChatSend must be used within ChatSendProvider");
+  return ctx;
+}

--- a/apps/web/src/lib/ai/system-prompt.ts
+++ b/apps/web/src/lib/ai/system-prompt.ts
@@ -29,7 +29,15 @@ e-be はイベント主催者・店舗向けのイベント運営・分析プラ
   - 変更したいフィールドだけ渡せばよいです（省略したフィールドは変更されません）
   - draft ステータスのイベントのみ修正可能です
 - 作成・修正されるのは「下書き」状態です。申請・公開は管理画面から行う必要があります
-- 未ログインの場合はイベントの作成・修正ができません`;
+- 未ログインの場合はイベントの作成・修正ができません
+
+## クイックリプライ（suggestReplies ツール）
+
+- 選択肢が明確な質問をするときは必ず suggestReplies ツールを呼んで候補を提示してから質問してください
+  - 例: 「チャージ料はありますか？」→ suggestReplies(["無料（0円）", "500円", "1,000円", "2,000円", "その他"])
+  - 例: 「このバーで作成しますか？」→ suggestReplies(["はい", "別のバーを選ぶ"])
+- suggestReplies のあとに質問テキストを出力してください（順序: テキスト → suggestReplies）
+- 日時の候補は suggest-dates ツール（別途実装予定）で提示してください`;
 
 export function buildSystemPrompt(pageContext?: ChatPageContext): string {
   if (!pageContext || (!pageContext.eventId && !pageContext.orgId && !pageContext.pageName)) {

--- a/apps/web/src/lib/ai/tools/index.ts
+++ b/apps/web/src/lib/ai/tools/index.ts
@@ -5,6 +5,7 @@ import { createCreateEventTool } from "./create-event";
 import { createListEventsTool } from "./list-events";
 import { createUpdateEventTool } from "./update-event";
 import { createSubmitEventTool } from "./submit-event";
+import { suggestRepliesTool } from "./suggest-replies";
 import type { getDbUser } from "@/lib/auth";
 
 type DbUser = Awaited<ReturnType<typeof getDbUser>>;
@@ -17,4 +18,5 @@ export const createTools = (dbUser: DbUser) => ({
   listEvents: createListEventsTool(dbUser),
   updateEvent: createUpdateEventTool(dbUser),
   submitEvent: createSubmitEventTool(dbUser),
+  suggestReplies: suggestRepliesTool,
 });

--- a/apps/web/src/lib/ai/tools/suggest-replies.ts
+++ b/apps/web/src/lib/ai/tools/suggest-replies.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const suggestRepliesTool = tool({
+  description:
+    "ユーザーへのクイックリプライ候補を提示する。選択肢が明確な質問（日時・金額・はい/いいえ等）をするときに呼ぶ。",
+  inputSchema: z.object({
+    replies: z
+      .array(z.string().max(30))
+      .max(8)
+      .describe("選択肢（最大8件、各30文字以内）"),
+  }),
+  execute: async ({ replies }) => ({ replies }),
+});


### PR DESCRIPTION
## 概要

イベント作成フローなどで AI が「チャージ料は？」「このバーで作成しますか？」と聞くとき、ユーザーがクリックで回答できる**クイックリプライチップ**を会話中に表示できるようにする。

## 変更内容

- `suggestReplies` ツールを新規追加（副作用ゼロのパススルーツール。AI が選択肢配列を返す）
- `ChatSendContext` を新設し、`sendMessage` / `isLoading` を下流コンポーネントに共有
- `ChatWidget` を `ChatSendProvider` でラップ
- `SuggestRepliesResult` コンポーネントを追加（ツール結果としてチップUIをレンダリング）
- ツール結果レジストリ (`tool-suggestReplies`) に登録
- システムプロンプトに `suggestReplies` の使用ガイドライン（選択肢が明確な質問時に必ず使うこと）を追記

## 関連 Issue

Closes #216

## 確認方法

- [ ] ダッシュボードで AI チャットを開き「新しいイベントを作成したい」と送信する
- [ ] AI が「チャージ料は？」などの選択肢質問をするとき、クリッカブルなチップが表示される
- [ ] チップをクリックするとメッセージが即座に送信される
- [ ] AI 応答待ち（`isLoading`）中はチップが非活性になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)