### PR TITLE
security: Server Actions と Auth bypass の脆弱性を修正

### DIFF
--- a/apps/web/src/app/[locale]/admin/applications/actions.ts
+++ b/apps/web/src/app/[locale]/admin/applications/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
+import { getDbUser, isAdmin } from "@/lib/auth";
 import {
   operatorApplications,
   companies,
@@ -17,6 +18,11 @@ export async function approveApplication(
   _prev: State,
   formData: FormData
 ): Promise<State> {
+  const dbUser = await getDbUser();
+  if (!dbUser || !(await isAdmin(dbUser.id))) {
+    return { success: false, error: "Unauthorized" };
+  }
+
   const applicationId = String(formData.get("applicationId") ?? "");
   const applicantUserId = String(formData.get("applicantUserId") ?? "");
   const orgName = String(formData.get("orgName") ?? "");
@@ -24,7 +30,6 @@ export async function approveApplication(
   const companyName = String(formData.get("companyName") ?? "");
   const address = String(formData.get("address") ?? "") || null;
   const description = String(formData.get("description") ?? "") || null;
-  const reviewerUserId = String(formData.get("reviewerUserId") ?? "");
   const locale = String(formData.get("locale") ?? "ja");
 
   // トランザクション: 会社 → 組織 → メンバー → userType 更新 → 申請ステータス更新
@@ -68,7 +73,7 @@ export async function approveApplication(
       .update(operatorApplications)
       .set({
         status: "approved",
-        reviewedBy: reviewerUserId,
+        reviewedBy: dbUser.id,
         reviewedAt: new Date(),
       })
       .where(eq(operatorApplications.id, applicationId));
@@ -81,8 +86,12 @@ export async function rejectApplication(
   _prev: State,
   formData: FormData
 ): Promise<State> {
+  const dbUser = await getDbUser();
+  if (!dbUser || !(await isAdmin(dbUser.id))) {
+    return { success: false, error: "Unauthorized" };
+  }
+
   const applicationId = String(formData.get("applicationId") ?? "");
-  const reviewerUserId = String(formData.get("reviewerUserId") ?? "");
   const reviewNote = String(formData.get("reviewNote") ?? "") || null;
   const locale = String(formData.get("locale") ?? "ja");
 
@@ -90,7 +99,7 @@ export async function rejectApplication(
     .update(operatorApplications)
     .set({
       status: "rejected",
-      reviewedBy: reviewerUserId,
+      reviewedBy: dbUser.id,
       reviewedAt: new Date(),
       reviewNote,
     })

--- a/apps/web/src/app/[locale]/admin/applications/page.tsx
+++ b/apps/web/src/app/[locale]/admin/applications/page.tsx
@@ -121,7 +121,6 @@ export default async function AdminApplicationsPage() {
                       companyName={app.companyName}
                       address={app.address}
                       description={app.description}
-                      reviewerUserId={user.id}
                       locale={locale}
                     />
                   )}

--- a/apps/web/src/app/[locale]/admin/applications/review-actions.tsx
+++ b/apps/web/src/app/[locale]/admin/applications/review-actions.tsx
@@ -15,7 +15,6 @@ type Props = {
   companyName: string;
   address: string | null;
   description: string | null;
-  reviewerUserId: string;
   locale: string;
 };
 
@@ -27,7 +26,6 @@ export function ReviewActions({
   companyName,
   address,
   description,
-  reviewerUserId,
   locale,
 }: Props) {
   const t = useTranslations("admin");
@@ -62,7 +60,6 @@ export function ReviewActions({
         <input type="hidden" name="companyName" value={companyName} />
         <input type="hidden" name="address" value={address ?? ""} />
         <input type="hidden" name="description" value={description ?? ""} />
-        <input type="hidden" name="reviewerUserId" value={reviewerUserId} />
         <input type="hidden" name="locale" value={locale} />
         <Button
           type="submit"
@@ -77,7 +74,6 @@ export function ReviewActions({
 
       <form action={rejectAction} className="space-y-2">
         <input type="hidden" name="applicationId" value={applicationId} />
-        <input type="hidden" name="reviewerUserId" value={reviewerUserId} />
         <input type="hidden" name="locale" value={locale} />
         <div className="space-y-1.5">
           <Label htmlFor={`note-${applicationId}`} className="text-xs">

--- a/apps/web/src/app/[locale]/auth/sign-in/page.tsx
+++ b/apps/web/src/app/[locale]/auth/sign-in/page.tsx
@@ -11,9 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { createClient } from "@/lib/supabase/client";
 
 // --- BYPASS START ---
-const BYPASS_ENABLED =
-  process.env.NEXT_PUBLIC_BYPASS_AUTH === "true" ||
-  !!process.env.NEXT_PUBLIC_VERCEL_ENV;
+const BYPASS_ENABLED = process.env.NEXT_PUBLIC_BYPASS_AUTH === "true";
 
 const TEST_ACCOUNTS = [
   {

--- a/apps/web/src/app/[locale]/dashboard/apply/actions.ts
+++ b/apps/web/src/app/[locale]/dashboard/apply/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { db } from "@/lib/db";
+import { getDbUser } from "@/lib/auth";
 import { operatorApplications, organizations } from "@e-be/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
 
@@ -10,7 +11,12 @@ export async function submitApplication(
   _prev: State,
   formData: FormData
 ): Promise<State> {
-  const userId = String(formData.get("userId") ?? "").trim();
+  const dbUser = await getDbUser();
+  if (!dbUser) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const userId = dbUser.id;
   const companyName = String(formData.get("companyName") ?? "").trim();
   const orgName = String(formData.get("orgName") ?? "").trim();
   const orgSlug = String(formData.get("orgSlug") ?? "").trim().toLowerCase();

--- a/apps/web/src/app/[locale]/dashboard/apply/apply-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/apply/apply-form.tsx
@@ -9,11 +9,10 @@ import { Label } from "@/components/ui/label";
 import { submitApplication } from "./actions";
 
 type Props = {
-  userId: string;
   locale: string;
 };
 
-export function ApplyForm({ userId, locale }: Props) {
+export function ApplyForm({ locale }: Props) {
   const t = useTranslations("apply");
   const [state, action, isPending] = useActionState(submitApplication, null);
 
@@ -37,7 +36,6 @@ export function ApplyForm({ userId, locale }: Props) {
 
   return (
     <form action={action} className="space-y-4">
-      <input type="hidden" name="userId" value={userId} />
       <input type="hidden" name="locale" value={locale} />
 
       <div className="space-y-1.5">

--- a/apps/web/src/app/[locale]/dashboard/apply/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/apply/page.tsx
@@ -66,7 +66,7 @@ export default async function ApplyPage() {
             <p className="text-sm text-muted-foreground">{t("description")}</p>
           </CardHeader>
           <CardContent>
-            <ApplyForm userId={user.id} locale={locale} />
+            <ApplyForm locale={locale} />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
セキュリティ監査で発見された2つの脆弱性を修正：

- **Issue #230**: Server Actions（approveApplication/rejectApplication/submitApplication）に認証チェックがない
  - FormData から \`userId\`/\`reviewerUserId\` を信頼していたため、未認証ユーザーが管理操作を実行可能
  - セッションから認証ユーザーの ID を取得し、FormData からは読まないよう変更

- **Issue #231**: NEXT_PUBLIC_VERCEL_ENV による無意識な Auth bypass 有効化
  - Vercel の全デプロイで自動的にテスト認証パネルが表示されていた
  - \`NEXT_PUBLIC_BYPASS_AUTH === "true"\` のみの条件に修正

## Test Plan
- [ ] 未認証状態で \`/admin/applications\` にアクセス → 401 相当のエラー
- [ ] FormData を改ざんして \`approveApplication\` を呼び出し → 401 相当のエラー
- [ ] ローカルで \`NEXT_PUBLIC_BYPASS_AUTH\` 未設定時、テストパネルが非表示
- [ ] \`NEXT_PUBLIC_BYPASS_AUTH=true\` 設定時、テストパネルが表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)