### PR TITLE
feat: イベントカードに主催者お気に入りボタンを追加

### DIFF
--- a/apps/web/src/app/[locale]/events/events-list.tsx
+++ b/apps/web/src/app/[locale]/events/events-list.tsx
@@ -7,6 +7,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { Button } from "@/components/ui/button";
 import type { PublicEventItem } from "@/lib/events";
 import { fetchPublicEventsAction } from "./actions";
+import { OrganizerWatchButton } from "./[eventId]/organizer-watch-button";
 
 const PAGE_SIZE = 12;
 
@@ -15,10 +16,13 @@ type Props = {
   initialHasNext: boolean;
   area?: string;
   line?: string;
+  loggedInUserId?: string | null;
+  watchedUserIds?: string[];
 };
 
-export function EventsList({ initialEvents, initialHasNext, area, line }: Props) {
+export function EventsList({ initialEvents, initialHasNext, area, line, loggedInUserId, watchedUserIds = [] }: Props) {
   const t = useTranslations("events");
+  const tDetail = useTranslations("event_detail");
   const locale = useLocale();
   const [items, setItems] = useState<PublicEventItem[]>(initialEvents);
   const [hasMore, setHasMore] = useState(initialHasNext);
@@ -152,7 +156,34 @@ export function EventsList({ initialEvents, initialHasNext, area, line }: Props)
                   ) : (
                     <p className="truncate">{event.orgName}</p>
                   )}
+                </div>
 
+                {/* 主催者 + お気に入りボタン */}
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground truncate">
+                    {event.organizerName ?? tDetail("organizer_unknown")}
+                  </span>
+                  {loggedInUserId !== event.organizerUserId && (
+                    loggedInUserId ? (
+                      <OrganizerWatchButton
+                        targetUserId={event.organizerUserId}
+                        initialWatching={watchedUserIds.includes(event.organizerUserId)}
+                        watchLabel={tDetail("watch_organizer")}
+                        unwatchLabel={tDetail("unwatch_organizer")}
+                        watchSuccess={tDetail("toast_watch_success")}
+                        unwatchSuccess={tDetail("toast_unwatch_success")}
+                        errorLabel={tDetail("toast_watch_error")}
+                      />
+                    ) : (
+                      <Link
+                        href={`/${locale}/auth/sign-in?next=/${locale}/events`}
+                        aria-label={tDetail("watch_organizer")}
+                        className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        ♡
+                      </Link>
+                    )
+                  )}
                 </div>
 
                 <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-2 text-xs">

--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -4,7 +4,8 @@ import { EventsFilter } from "./events-filter";
 import { EventsList } from "./events-list";
 import { AppFooter } from "@/components/layout/app-footer";
 import { PublicHeader } from "@/components/layout/public-header";
-import { getUser } from "@/lib/auth";
+import { getUser, getDbUser } from "@/lib/auth";
+import { getWatchedUserIds } from "@/lib/actions/watch";
 
 const PAGE_SIZE = 12;
 
@@ -14,20 +15,18 @@ type SearchParams = Promise<{
 }>;
 
 export default async function EventsPage({ searchParams }: { searchParams: SearchParams }) {
-  const [{ area, line }, user, availableLines] = await Promise.all([
+  const [{ area, line }, user, dbUser, availableLines] = await Promise.all([
     searchParams,
     getUser(),
+    getDbUser(),
     getAvailableLines(),
   ]);
   const t = await getTranslations("events");
 
-  // 初回表示分を取得（1件多く取得して hasNext を判定）
-  const items = await searchPublicEvents({
-    area,
-    line,
-    limit: PAGE_SIZE + 1,
-    offset: 0,
-  });
+  const [items, watchedUserIds] = await Promise.all([
+    searchPublicEvents({ area, line, limit: PAGE_SIZE + 1, offset: 0 }),
+    dbUser ? getWatchedUserIds(dbUser.id) : Promise.resolve([]),
+  ]);
 
   const hasNext = items.length > PAGE_SIZE;
   const initialEvents = hasNext ? items.slice(0, PAGE_SIZE) : items;
@@ -50,6 +49,8 @@ export default async function EventsPage({ searchParams }: { searchParams: Searc
             initialHasNext={hasNext}
             area={area}
             line={line}
+            loggedInUserId={dbUser?.id ?? null}
+            watchedUserIds={watchedUserIds}
           />
         </div>
       </main>

--- a/apps/web/src/lib/actions/watch.ts
+++ b/apps/web/src/lib/actions/watch.ts
@@ -74,3 +74,16 @@ export async function isWatchingUser(targetUserId: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+export async function getWatchedUserIds(userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ targetUserId: userWatches.targetUserId })
+    .from(userWatches)
+    .where(
+      and(
+        eq(userWatches.watcherUserId, userId),
+        isNull(userWatches.deletedAt)
+      )
+    );
+  return rows.map((r) => r.targetUserId);
+}
+

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -613,6 +613,8 @@ export type PublicEventItem = {
   maxParticipants: number | null;
   participantCount: number;
   thumbnailUrl: string | null;
+  organizerUserId: string;
+  organizerName: string | null;
 };
 
 export type SearchEventsOptions = {
@@ -693,9 +695,12 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
       maxParticipants: events.maxParticipants,
       participantCount: sql<number>`(${participantCountSq})`,
       thumbnailUrl: events.thumbnailUrl,
+      organizerUserId: events.userId,
+      organizerName: users.name,
     })
     .from(events)
     .innerJoin(organizations, eq(events.orgId, organizations.id))
+    .innerJoin(users, eq(events.userId, users.id))
     .where(and(...conditions))
     .orderBy(asc(events.startAt))
     .limit(limit)
@@ -716,6 +721,8 @@ export async function searchPublicEvents(opts: SearchEventsOptions = {}): Promis
     maxParticipants: row.maxParticipants,
     participantCount: Number(row.participantCount),
     thumbnailUrl: row.thumbnailUrl,
+    organizerUserId: row.organizerUserId,
+    organizerName: row.organizerName ?? null,
   }));
 }
 


### PR DESCRIPTION
## Summary

- Issue #139: ユーザーへのいいね機能（user_likes）の残作業実装
- イベント一覧カードに主催者名 + ♡ ボタンを追加
- 既存の `userWatches` テーブル・`OrganizerWatchButton` コンポーネントを再利用

## 変更内容

- `searchPublicEvents` に `organizerUserId` / `organizerName` フィールドを追加（users テーブルを JOIN）
- `getWatchedUserIds(userId)` を `watch.ts` に追加（一括取得してカード初期状態に使用）
- `EventsList` に `loggedInUserId` / `watchedUserIds` props を追加
- イベントカード下部に主催者名 + お気に入りボタンを表示
  - ログイン済み: `OrganizerWatchButton`（ハートアイコン、トグル可能）
  - 未ログイン: サインインリンク（♡）
  - 自分自身のイベント: ボタン非表示

## Test Plan

- [ ] イベント一覧ページで各カードに主催者名とハートボタンが表示される
- [ ] ログイン状態でボタンをクリックするとお気に入り状態がトグルされる
- [ ] 未ログイン状態ではサインインリンクが表示される
- [ ] 自分が主催するイベントカードにはボタンが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)