### PR TITLE
feat: 外部 Google カレンダーをダッシュボードに表示 (#14)

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { EventCalendar } from "@/components/event-calendar";
 import { getEventsForCalendar, getMyDraftEvents, getOrganizerHistory, getParticipationHistory, getUpcomingParticipations, searchPublicEvents } from "@/lib/events";
+import { getGoogleCalendarEvents } from "@/lib/google-calendar";
 import { OrganizerHistoryItem } from "./organizer-history-item";
 
 const USER_TYPE_VARIANT = {
@@ -25,12 +26,15 @@ export default async function DashboardPage() {
   const calendarFrom = new Date(now.getFullYear(), now.getMonth(), 1);
   const calendarTo = new Date(now.getFullYear(), now.getMonth() + 3, 0);
 
-  const [userOrgs, userType, calendarEvents, upcomingPublicEvents] = await Promise.all([
+  const [userOrgs, userType, calendarEvents, externalEvents, upcomingPublicEvents] = await Promise.all([
     getUserOrgs(user.id),
     getUserType(user.id),
     getEventsForCalendar({ from: calendarFrom, to: calendarTo }),
+    getGoogleCalendarEvents(calendarFrom, calendarTo),
     searchPublicEvents({ limit: 3 }),
   ]);
+
+  const allCalendarEvents = [...calendarEvents, ...externalEvents];
 
   // userType === 'user' のみ必要なデータを並行取得
   let organizerHistory: Awaited<ReturnType<typeof getOrganizerHistory>> = [];
@@ -76,7 +80,7 @@ export default async function DashboardPage() {
               </CardHeader>
               <CardContent>
                 <EventCalendar
-                  events={calendarEvents}
+                  events={allCalendarEvents}
                   initialYear={now.getFullYear()}
                   initialMonth={now.getMonth()}
                   locale={locale}

--- a/apps/web/src/components/event-calendar.tsx
+++ b/apps/web/src/components/event-calendar.tsx
@@ -166,18 +166,22 @@ export function EventCalendar({
               {/* イベントチップ（最大2件表示） */}
               {dayEvents.slice(0, 2).map((event) => {
                 const isPending = event.status === "pending";
+                const isExternal = event.source === "external";
                 return (
                   <div
                     key={event.id}
                     title={event.title ?? ""}
                     className={cn(
                       "truncate rounded px-1 py-px text-[10px] leading-tight",
-                      isPending
-                        ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-                        : "bg-primary/15 text-primary"
+                      isExternal
+                        ? "bg-green-500/15 text-green-700 dark:text-green-400"
+                        : isPending
+                          ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                          : "bg-primary/15 text-primary"
                     )}
                   >
-                    {isPending && "⏳ "}
+                    {isExternal && "🌐 "}
+                    {!isExternal && isPending && "⏳ "}
                     {event.title ?? (locale === "ja" ? "イベント" : "Event")}
                   </div>
                 );

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -176,6 +176,7 @@ export type CalendarEventData = {
   title: string | null;
   startAt: string | null; // ISO 8601 文字列（Server→Client 境界でシリアライズ済み）
   status: 'published' | 'pending';
+  source?: 'external';
 };
 
 type GetEventsForCalendarOptions = {

--- a/apps/web/src/lib/google-calendar.ts
+++ b/apps/web/src/lib/google-calendar.ts
@@ -1,0 +1,54 @@
+import type { CalendarEventData } from "@/lib/events";
+
+const CALENDAR_ID =
+  "jjl7dmes381n9kt27u225g6lr0@group.calendar.google.com";
+
+type GoogleCalendarEvent = {
+  id: string;
+  summary?: string;
+  start?: { dateTime?: string; date?: string };
+};
+
+type GoogleCalendarResponse = {
+  items?: GoogleCalendarEvent[];
+};
+
+export async function getGoogleCalendarEvents(
+  from: Date,
+  to: Date
+): Promise<CalendarEventData[]> {
+  const apiKey = process.env.GOOGLE_CALENDAR_API_KEY;
+  if (!apiKey) return [];
+
+  const params = new URLSearchParams({
+    key: apiKey,
+    timeMin: from.toISOString(),
+    timeMax: to.toISOString(),
+    singleEvents: "true",
+    orderBy: "startTime",
+    maxResults: "50",
+  });
+
+  try {
+    const res = await fetch(
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(CALENDAR_ID)}/events?${params}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+
+    const data: GoogleCalendarResponse = await res.json();
+    const items = data.items ?? [];
+
+    return items
+      .map((item) => ({
+        id: `gcal-${item.id}`,
+        title: item.summary ?? null,
+        startAt: item.start?.dateTime ?? item.start?.date ?? null,
+        status: "published" as const,
+        source: "external" as const,
+      }))
+      .filter((e) => e.startAt !== null);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## 概要

知人店舗（eventbareden.com）の公開 Google カレンダーのイベントを取得し、ダッシュボードのカレンダーに重ねて表示する。デモ・検証用途。

## 変更内容

- `apps/web/src/lib/google-calendar.ts` — Google Calendar API v3 でイベントを取得する `getGoogleCalendarEvents()` を新規追加
- `apps/web/src/lib/events.ts` — `CalendarEventData` に `source?: "external"` フィールドを追加
- `apps/web/src/app/[locale]/dashboard/page.tsx` — 外部イベントを並行取得・既存イベントとマージ
- `apps/web/src/components/event-calendar.tsx` — 外部イベントを緑チップ（🌐）で表示

## 動作仕様

- `GOOGLE_CALENDAR_API_KEY` 環境変数が未設定の場合は空配列を返し、既存カレンダー表示に影響なし
- 外部イベントは 1 時間キャッシュ（`next: { revalidate: 3600 }`）

## 事前準備（手動）

1. Google Cloud Console で Google Calendar API を有効化し API キーを発行
2. `apps/web/.env.local` に `GOOGLE_CALENDAR_API_KEY=xxx` を追加
3. Vercel 環境変数にも同じキーを追加

## 関連 Issue

Closes #14

## 確認方法

- [ ] `GOOGLE_CALENDAR_API_KEY` を設定してダッシュボードを開き、緑の 🌐 チップが表示される
- [ ] キー未設定でもカレンダーが正常表示される（エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)