### PR TITLE
fix: SNS投稿生成が失敗する問題を修正 (#241)

### DIFF
--- a/apps/web/src/lib/actions/sns-assist.ts
+++ b/apps/web/src/lib/actions/sns-assist.ts
@@ -1,20 +1,21 @@
 "use server";
 
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { generateObject } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { z } from "zod";
 import { getEventDetail } from "@/lib/events";
 import { getUser } from "@/lib/auth";
 
-type SnsContent = {
-  xPost: string;
-  imagePrompt: string;
-};
+const snsSchema = z.object({
+  xPost: z.string().describe("X（Twitter）投稿文言（140文字以内、ハッシュタグ含む、日本語）"),
+  imagePrompt: z.string().describe("SNS画像生成用英語プロンプト（Midjourney/DALL-E向け、英語）"),
+});
 
-type Result = { ok: true; data: SnsContent } | { ok: false; error: string };
+type Result =
+  | { ok: true; data: z.infer<typeof snsSchema> }
+  | { ok: false; error: string };
 
 export async function generateSnsContent(eventId: string): Promise<Result> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) return { ok: false, error: "API key not configured" };
-
   const user = await getUser();
   if (!user) return { ok: false, error: "Unauthorized" };
 
@@ -22,37 +23,28 @@ export async function generateSnsContent(eventId: string): Promise<Result> {
   if (!event) return { ok: false, error: "Event not found" };
   if (event.organizerUserId !== user.id) return { ok: false, error: "Forbidden" };
 
-  const prompt = `以下のイベント情報を元に、2つのコンテンツをJSON形式で生成してください。
+  const google = createGoogleGenerativeAI({
+    apiKey: process.env.GEMINI_API_KEY ?? "",
+  });
+
+  const prompt = `以下のイベント情報を元に、SNSコンテンツを生成してください。
 
 イベント情報:
 - タイトル: ${event.title ?? "未設定"}
 - 日時: ${event.startAt ? new Date(event.startAt).toLocaleString("ja-JP") : "未設定"}
 - 場所: ${event.location ?? "未設定"}
-- 説明: ${event.description ?? "なし"}
-
-出力形式（JSONのみ、説明文不要）:
-{
-  "xPost": "X（Twitter）投稿文言（140文字以内、ハッシュタグ含む、日本語）",
-  "imagePrompt": "SNS画像生成用英語プロンプト（Midjourney/DALL-E向け、英語）"
-}`;
+- 説明: ${event.description ?? "なし"}`;
 
   try {
-    const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
-    const result = await model.generateContent(prompt);
-    const text = result.response.text().trim();
+    const { object } = await generateObject({
+      model: google("gemini-2.5-flash"),
+      schema: snsSchema,
+      prompt,
+    });
 
-    // ```json ... ``` のコードブロックを除去
-    const jsonText = text.replace(/^```json\s*/i, "").replace(/\s*```$/, "").trim();
-    const parsed = JSON.parse(jsonText) as SnsContent;
-
-    if (!parsed.xPost || !parsed.imagePrompt) {
-      return { ok: false, error: "Invalid response format" };
-    }
-
-    return { ok: true, data: parsed };
+    return { ok: true, data: object };
   } catch (e) {
-    console.error("Gemini API error:", e);
+    console.error("SNS content generation error:", e);
     return { ok: false, error: "Generation failed. Please try again." };
   }
 }


### PR DESCRIPTION
## 概要

「SNS投稿を作成」で「生成に失敗しました」が表示される問題を修正。
旧 SDK（`@google/generative-ai`）の手動 JSON パースを廃止し、`generateObject` + Zod スキーマに移行。

## 変更内容

- `apps/web/src/lib/actions/sns-assist.ts`
  - `@google/generative-ai` → `@ai-sdk/google` + `ai` の `generateObject` に移行
  - 手動 JSON パース・コードブロック除去処理を削除
  - Zod スキーマで構造化出力を保証（パース失敗ゼロ）
  - チャット API と同じ SDK・環境変数（`GEMINI_API_KEY`）を統一使用

## 関連 Issue

Closes #241

## 確認方法

- [x] イベント詳細ページで「SNS投稿を作成 → 生成する」が正常に動作
- [x] X投稿文・画像生成プロンプトが両方表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)